### PR TITLE
Document Zoë context editing feature

### DIFF
--- a/core-concepts/context-surfaces.md
+++ b/core-concepts/context-surfaces.md
@@ -97,45 +97,13 @@ Memories are retained for backward compatibility and will be migrated to skills 
 
 ## Letting Zoë edit context for you
 
-You can allow Zoë to make changes to your data model and tell her to save them, instead of pasting her recommendations into [Context Manager](../zenlytic-ui/context_manager.md) yourself. When [this is on](#turn-it-on-or-off), Zoë can read, edit, validate, and commit changes to your repository on the branch you're working on.
+Zoë can also write to these surfaces, not just read them. When enabled for your workspace, you can ask her to add a field, update a view or field description, edit the `system_prompt.md`, or create and update skills, and she'll commit the change to your repository for you.
 
-The surfaces she can write to:
-
-* Data model YAML under `views/`, `models/`, `topics/`, and `dashboards/`, plus `zenlytic_project.yml`
-* The workspace `system_prompt.md`, for universal rules and shared domain knowledge
-* Workspace `skills/`, including `skills/<skill-name>/SKILL.md` and any supporting files
-
-Tell Zoë what you want to change ("add a measure for repeat purchase rate", "update the system prompt to default to net revenue", "create a skill for our fiscal calendar") and ask her to save it. She'll draft the smallest correct edit, validate the data model with `validate_context`, commit and push the change with `save_context`, and run a quick sample query to confirm the edit works. If validation fails, she fixes the referenced files and validates again before saving, so no partial commits land.
-
-If you'd rather have Zoë just review without editing, ask her to "audit the model", "find improvements", or "check whether you have enough context". She'll inspect the data model and report recommendations without saving anything.
-
-### Turn it on or off
-
-The feature is on by default for workspaces that have access to it. You can toggle it per workspace at:
-
-**Workspace Settings → Zoë → Context Editing**
-
-When the toggle is **on**, Zoë can save changes to your data model from chat, subject to the permission rules below. When the toggle is **off**, Zoë will still draft snippets when you ask, but she won't write them to your repository.
-
-### Zoë inherits your permissions
-
-When the toggle is on, Zoë's editing permissions match yours. The data model uses the same role-based rules whether you edit by hand in Context Manager or ask Zoë to do it from chat:
-
-* If you are an **Explore**, **View**, or **Restricted** user (or any role without `data_model_edit`), Zoë cannot edit the data model. She'll draft recommendations instead.
-* If you are **Develop**, **Develop without Deploy**, or **Admin**, Zoë can edit the data model on the branch you're currently on, as long as that branch isn't the production branch.
-* Only workspace **Admins** and users with the **Develop** role can deploy a development branch to the production branch. Deployment happens in [Context Manager](../zenlytic-ui/context_manager.md), not from chat.
-
-See [User Roles](../zenlytic-ui/user_roles.md) for the full role and permission reference.
-
-#### Editing the production branch directly
-
-You can allow Zoë to save edits on the production branch by turning on the **Allow Edit Production** toggle at **Workspace Settings → Git → Allow Edit Production**. With the toggle on, Zoë will save changes on the production branch for **Admin** and **Develop** users. With it off, she'll refuse production edits and ask you to switch to a development branch. The toggle is on by default and uses the same setting that controls manual production edits in Context Manager. See [Work with branches safely](../zenlytic-ui/context_manager.md#work-with-branches-safely) for more on the toggle.
+The full feature, including how to turn it on or off, the role-based permission rules, and how production-branch edits are handled, is documented in [Ask Zoë for Data Model Recommendations](../data-modeling/asking-zoe-for-recommendations.md).
 
 ## Related pages
 
-* [Ask Zoë for Data Model Recommendations](../data-modeling/asking-zoe-for-recommendations.md): concrete examples of asking Zoë for help and letting her save the change
-* [Context Manager](../zenlytic-ui/context_manager.md): the UI for browsing, editing, and deploying context manually
-* [User Roles](../zenlytic-ui/user_roles.md): the role and permission reference Zoë inherits from
+* [Ask Zoë for Data Model Recommendations](../data-modeling/asking-zoe-for-recommendations.md): how Zoë can write to these surfaces for you
 * [Skills](../zenlytic-ui/skills.md) — how to create and use skills
 * [Views](../data-modeling/view.md) — view-level descriptions
 * [Dimensions](../data-modeling/dimension.md) — field-level descriptions, synonyms, searchable

--- a/core-concepts/context-surfaces.md
+++ b/core-concepts/context-surfaces.md
@@ -127,7 +127,7 @@ When the toggle is on, Zoë's editing permissions match yours. The data model us
 
 #### Editing the production branch directly
 
-Asking Zoë to save a change on the production branch is gated by the same workspace setting that gates manual production edits in Context Manager: the **Allow Edit Production** toggle at **Workspace Settings → Git → Allow Edit Production** (on by default). Zoë will save on the production branch only if you are an **Admin** or **Develop** user and the toggle is on. Otherwise she'll refuse the edit and ask you to switch to a development branch. See [Work with branches safely](../zenlytic-ui/context_manager.md#work-with-branches-safely) for more on the toggle.
+You can allow Zoë to save edits on the production branch by turning on the **Allow Edit Production** toggle at **Workspace Settings → Git → Allow Edit Production**. With the toggle on, Zoë will save changes on the production branch for **Admin** and **Develop** users. With it off, she'll refuse production edits and ask you to switch to a development branch. The toggle is on by default and uses the same setting that controls manual production edits in Context Manager. See [Work with branches safely](../zenlytic-ui/context_manager.md#work-with-branches-safely) for more on the toggle.
 
 See [User Roles](../zenlytic-ui/user_roles.md) for the full role and permission reference, and [Ask Zoë for Data Model Recommendations](../data-modeling/asking-zoe-for-recommendations.md) for concrete examples and the iteration playbook.
 

--- a/core-concepts/context-surfaces.md
+++ b/core-concepts/context-surfaces.md
@@ -121,7 +121,7 @@ When the toggle is **on**, Zoë can save changes to your data model from chat, s
 
 When the toggle is on, Zoë's editing permissions match yours. The data model uses the same role-based rules whether you edit by hand in Context Manager or ask Zoë to do it from chat:
 
-* If you are an **Explore** or **View** user (or any role without `data_model_edit`), Zoë cannot edit the data model. She will draft recommendations instead.
+* If you are an **Explore**, **View**, or **Restricted** user (or any role without `data_model_edit`), Zoë cannot edit the data model. She will draft recommendations instead.
 * If you are **Develop**, **Develop without Deploy**, or **Admin**, Zoë can edit the data model on the branch you are currently on, as long as that branch is not the production branch.
 * Only workspace **Admins** and users with the **Develop** role (which carries `deploy_to_production`) can deploy a development branch to the production branch. Deployment happens in [Context Manager](../zenlytic-ui/context_manager.md), not from chat.
 

--- a/core-concepts/context-surfaces.md
+++ b/core-concepts/context-surfaces.md
@@ -95,8 +95,40 @@ Use the following mental model:
 
 Memories are retained for backward compatibility and will be migrated to skills in a future release. Do not add new context to memories. See [Memories](../zenlytic-ui/memories.md) for the existing reference and [Migrating from Memories and Topics](../migrations/migrating-from-memories-and-topics.md) for the recommended replacement.
 
+## Letting Zoë edit context for you
+
+Zoë can do more than recommend changes — she can also create and edit your workspace context directly from chat when you ask her to. The surfaces she can write to:
+
+* **Data model YAML** under `views/`, `models/`, `topics/`, and `dashboards/`, plus `zenlytic_project.yml`
+* **The workspace `system_prompt.md`** — universal rules and shared domain knowledge
+* **Workspace `skills/`** — `skills/<skill-name>/SKILL.md` and supporting files for recurring workflows
+
+When you ask Zoë to make a change, she follows a consistent workflow: she reads the relevant files, drafts the smallest correct edit, validates the result against the data model, commits the change to your repository on the current branch, and then runs a quick sample query to confirm the edit behaves as expected. If validation fails she reads the error, fixes the referenced files, and tries again before saving.
+
+She can also do this in **review-only mode** without saving anything. If you ask Zoë to "audit the model", "find improvements", or "check whether you have enough context", she'll inspect the data model and report targeted recommendations without editing or committing.
+
+### Branch and permission rules
+
+Zoë respects the same branch-and-role rules as a human editor in [Context Manager](../zenlytic-ui/context_manager.md):
+
+* **Non-production branches:** users with `develop_without_deploy` (or higher) can have Zoë edit any file in the data model.
+* **Production branch:** edits require both `deploy_to_production` permission **and** the workspace's "Allow editing production" setting to be enabled. If either is missing, Zoë will refuse the edit and explain how to either switch to a development branch or get the right permission.
+* **Below `develop_without_deploy`:** Zoë treats the workspace as read-only and will not save anything. She'll still recommend changes; you can apply them yourself in [Context Manager](../zenlytic-ui/context_manager.md), or ask a workspace admin.
+
+### Turn it on or off
+
+The feature is on by default for workspaces that have access to it. You can toggle it per workspace at:
+
+**Workspace Settings → Chat Settings → Context Editing**
+
+When the toggle is **on**, Zoë can sync, validate, and save changes to your data model context from chat. When it's **off**, Zoë can still recommend changes — she just won't write them — and you apply the recommendations yourself.
+
+For the full recommend-vs-apply workflow with concrete examples, see [Ask Zoë for Data Model Recommendations](../data-modeling/asking-zoe-for-recommendations.md).
+
 ## Related pages
 
+* [Ask Zoë for Data Model Recommendations](../data-modeling/asking-zoe-for-recommendations.md) — the recommend vs. apply flow with concrete examples
+* [Context Manager](../zenlytic-ui/context_manager.md) — the UI for browsing, editing, and deploying context manually
 * [Skills](../zenlytic-ui/skills.md) — how to create and use skills
 * [Views](../data-modeling/view.md) — view-level descriptions
 * [Dimensions](../data-modeling/dimension.md) — field-level descriptions, synonyms, searchable

--- a/core-concepts/context-surfaces.md
+++ b/core-concepts/context-surfaces.md
@@ -97,7 +97,7 @@ Memories are retained for backward compatibility and will be migrated to skills 
 
 ## Letting Zoë edit context for you
 
-You can allow Zoë to directly make changes to your data model and tell her to save them, instead of pasting recommendations into [Context Manager](../zenlytic-ui/context_manager.md) yourself. When this is on, Zoë can read, edit, validate, and commit changes to your repository on the branch you're currently working on.
+You can allow Zoë to directly make changes to your data model and tell her to save them, instead of pasting recommendations into [Context Manager](../zenlytic-ui/context_manager.md) yourself. When [this is on](#turn-it-on-or-off), Zoë can read, edit, validate, and commit changes to your repository on the branch you're currently working on.
 
 The surfaces she can write to:
 

--- a/core-concepts/context-surfaces.md
+++ b/core-concepts/context-surfaces.md
@@ -136,7 +136,7 @@ If either is missing, Zoë will refuse the edit and ask you to switch to a devel
 
 The Allow Edit Production toggle is on by default, and lives at:
 
-**Workspace Settings → Git Settings → Allow Edit Production**
+**Workspace Settings → Git → Allow Edit Production**
 
 Turn it off to enforce a branch-and-deploy workflow where every production change goes through a development branch followed by an explicit deploy step. Turn it on if you want users with `deploy_to_production` to be able to edit the production branch directly, including from chat.
 

--- a/core-concepts/context-surfaces.md
+++ b/core-concepts/context-surfaces.md
@@ -97,23 +97,17 @@ Memories are retained for backward compatibility and will be migrated to skills 
 
 ## Letting Zoë edit context for you
 
-Zoë can do more than recommend changes — she can also create and edit your workspace context directly from chat when you ask her to. The surfaces she can write to:
+You can allow Zoë to directly make changes to your data model and tell her to save them, instead of pasting recommendations into [Context Manager](../zenlytic-ui/context_manager.md) yourself. When this is on, Zoë can read, edit, validate, and commit changes to your repository on the branch you're currently working on.
 
-* **Data model YAML** under `views/`, `models/`, `topics/`, and `dashboards/`, plus `zenlytic_project.yml`
-* **The workspace `system_prompt.md`** — universal rules and shared domain knowledge
-* **Workspace `skills/`** — `skills/<skill-name>/SKILL.md` and supporting files for recurring workflows
+The surfaces she can write to:
 
-When you ask Zoë to make a change, she follows a consistent workflow: she reads the relevant files, drafts the smallest correct edit, validates the result against the data model, commits the change to your repository on the current branch, and then runs a quick sample query to confirm the edit behaves as expected. If validation fails she reads the error, fixes the referenced files, and tries again before saving.
+* Data model YAML under `views/`, `models/`, `topics/`, and `dashboards/`, plus `zenlytic_project.yml`
+* The workspace `system_prompt.md`, for universal rules and shared domain knowledge
+* Workspace `skills/`, including `skills/<skill-name>/SKILL.md` and any supporting files
 
-She can also do this in **review-only mode** without saving anything. If you ask Zoë to "audit the model", "find improvements", or "check whether you have enough context", she'll inspect the data model and report targeted recommendations without editing or committing.
+Tell Zoë what you want to change ("add a measure for repeat purchase rate", "update the system prompt to default to net revenue", "create a skill for our fiscal calendar") and ask her to save it. She will draft the smallest correct edit, validate the data model with `validate_context`, commit and push the change with `save_context`, and run a quick sample query to confirm the edit works. If validation fails, she fixes the referenced files and validates again before saving, so no partial commits land.
 
-### Branch and permission rules
-
-Zoë respects the same branch-and-role rules as a human editor in [Context Manager](../zenlytic-ui/context_manager.md):
-
-* **Non-production branches:** users with `develop_without_deploy` (or higher) can have Zoë edit any file in the data model.
-* **Production branch:** edits require both `deploy_to_production` permission **and** the workspace's "Allow editing production" setting to be enabled. If either is missing, Zoë will refuse the edit and explain how to either switch to a development branch or get the right permission.
-* **Below `develop_without_deploy`:** Zoë treats the workspace as read-only and will not save anything. She'll still recommend changes; you can apply them yourself in [Context Manager](../zenlytic-ui/context_manager.md), or ask a workspace admin.
+You can also keep Zoë in a review-only flow without saving anything. If you ask her to "audit the model", "find improvements", or "check whether you have enough context", she will inspect the data model and report recommendations instead of editing.
 
 ### Turn it on or off
 
@@ -121,14 +115,23 @@ The feature is on by default for workspaces that have access to it. You can togg
 
 **Workspace Settings → Chat Settings → Context Editing**
 
-When the toggle is **on**, Zoë can sync, validate, and save changes to your data model context from chat. When it's **off**, Zoë can still recommend changes — she just won't write them — and you apply the recommendations yourself.
+When the toggle is **on**, Zoë can save changes to your data model from chat, subject to the permission rules below. When the toggle is **off**, Zoë will still draft snippets when you ask, but she will not write them to your repository.
 
-For the full recommend-vs-apply workflow with concrete examples, see [Ask Zoë for Data Model Recommendations](../data-modeling/asking-zoe-for-recommendations.md).
+### Zoë inherits your permissions
+
+When the toggle is on, Zoë's editing permissions match yours. The data model uses the same role-based rules whether you edit by hand in Context Manager or ask Zoë to do it from chat:
+
+* If you are an **Explore** or **View** user (or any role without `data_model_edit`), Zoë cannot edit the data model. She will draft recommendations instead.
+* If you are **Develop**, **Develop without Deploy**, or **Admin**, Zoë can edit the data model on the branch you are currently on.
+* Only workspace **Admins** and users with the **Develop** role (which carries `deploy_to_production`) can deploy a development branch to the production branch. Direct edits to the production branch from chat additionally require the workspace's "Allow editing production" setting to be enabled; without it, Zoë will refuse and ask you to switch to a development branch.
+
+See [User Roles](../zenlytic-ui/user_roles.md) for the full role and permission reference, and [Ask Zoë for Data Model Recommendations](../data-modeling/asking-zoe-for-recommendations.md) for concrete examples and the iteration playbook.
 
 ## Related pages
 
-* [Ask Zoë for Data Model Recommendations](../data-modeling/asking-zoe-for-recommendations.md) — the recommend vs. apply flow with concrete examples
-* [Context Manager](../zenlytic-ui/context_manager.md) — the UI for browsing, editing, and deploying context manually
+* [Ask Zoë for Data Model Recommendations](../data-modeling/asking-zoe-for-recommendations.md): concrete examples of asking Zoë for help and letting her save the change
+* [Context Manager](../zenlytic-ui/context_manager.md): the UI for browsing, editing, and deploying context manually
+* [User Roles](../zenlytic-ui/user_roles.md): the role and permission reference Zoë inherits from
 * [Skills](../zenlytic-ui/skills.md) — how to create and use skills
 * [Views](../data-modeling/view.md) — view-level descriptions
 * [Dimensions](../data-modeling/dimension.md) — field-level descriptions, synonyms, searchable

--- a/core-concepts/context-surfaces.md
+++ b/core-concepts/context-surfaces.md
@@ -123,7 +123,7 @@ When the toggle is on, Zoë's editing permissions match yours. The data model us
 
 * If you are an **Explore**, **View**, or **Restricted** user (or any role without `data_model_edit`), Zoë cannot edit the data model. She will draft recommendations instead.
 * If you are **Develop**, **Develop without Deploy**, or **Admin**, Zoë can edit the data model on the branch you are currently on, as long as that branch is not the production branch.
-* Only workspace **Admins** and users with the **Develop** role (which carries `deploy_to_production`) can deploy a development branch to the production branch. Deployment happens in [Context Manager](../zenlytic-ui/context_manager.md), not from chat.
+* Only workspace **Admins** and users with the **Develop** role can deploy a development branch to the production branch. Deployment happens in [Context Manager](../zenlytic-ui/context_manager.md), not from chat.
 
 #### Editing the production branch directly
 

--- a/core-concepts/context-surfaces.md
+++ b/core-concepts/context-surfaces.md
@@ -97,7 +97,7 @@ Memories are retained for backward compatibility and will be migrated to skills 
 
 ## Letting Zoë edit context for you
 
-Zoë can also write to these surfaces, not just read them. When enabled for your workspace, you can ask her to add a field, update a view or field description, edit the `system_prompt.md`, or create and update skills, and she'll commit the change to your repository for you.
+Zoë can also write to these surfaces, not just read them. When enabled for your workspace, you can ask her to add a field, update a view or field description, edit the system prompt, or create and update skills, and she'll commit the change to your repository for you.
 
 The full feature, including how to turn it on or off, the role-based permission rules, and how production-branch edits are handled, is documented in [Ask Zoë for Data Model Recommendations](../data-modeling/asking-zoe-for-recommendations.md).
 

--- a/core-concepts/context-surfaces.md
+++ b/core-concepts/context-surfaces.md
@@ -122,8 +122,23 @@ When the toggle is **on**, Zoë can save changes to your data model from chat, s
 When the toggle is on, Zoë's editing permissions match yours. The data model uses the same role-based rules whether you edit by hand in Context Manager or ask Zoë to do it from chat:
 
 * If you are an **Explore** or **View** user (or any role without `data_model_edit`), Zoë cannot edit the data model. She will draft recommendations instead.
-* If you are **Develop**, **Develop without Deploy**, or **Admin**, Zoë can edit the data model on the branch you are currently on.
-* Only workspace **Admins** and users with the **Develop** role (which carries `deploy_to_production`) can deploy a development branch to the production branch. Direct edits to the production branch from chat additionally require the workspace's "Allow editing production" setting to be enabled; without it, Zoë will refuse and ask you to switch to a development branch.
+* If you are **Develop**, **Develop without Deploy**, or **Admin**, Zoë can edit the data model on the branch you are currently on, as long as that branch is not the production branch.
+* Only workspace **Admins** and users with the **Develop** role (which carries `deploy_to_production`) can deploy a development branch to the production branch. Deployment happens in [Context Manager](../zenlytic-ui/context_manager.md), not from chat.
+
+#### Editing the production branch directly
+
+Asking Zoë to save a change while you're on the production branch is a separate, gated flow on top of the rules above. Zoë will only save edits on the production branch when **both** of the following are true:
+
+* You have `deploy_to_production` (so you are an **Admin** or **Develop** user).
+* The workspace's **Allow Edit Production** toggle is on.
+
+If either is missing, Zoë will refuse the edit and ask you to switch to a development branch.
+
+The Allow Edit Production toggle is on by default, and lives at:
+
+**Workspace Settings → Git Settings → Allow Edit Production**
+
+Turn it off to enforce a branch-and-deploy workflow where every production change goes through a development branch followed by an explicit deploy step. Turn it on if you want users with `deploy_to_production` to be able to edit the production branch directly, including from chat.
 
 See [User Roles](../zenlytic-ui/user_roles.md) for the full role and permission reference, and [Ask Zoë for Data Model Recommendations](../data-modeling/asking-zoe-for-recommendations.md) for concrete examples and the iteration playbook.
 

--- a/core-concepts/context-surfaces.md
+++ b/core-concepts/context-surfaces.md
@@ -113,7 +113,7 @@ You can also keep Zoë in a review-only flow without saving anything. If you ask
 
 The feature is on by default for workspaces that have access to it. You can toggle it per workspace at:
 
-**Workspace Settings → Chat Settings → Context Editing**
+**Workspace Settings → Zoë → Context Editing**
 
 When the toggle is **on**, Zoë can save changes to your data model from chat, subject to the permission rules below. When the toggle is **off**, Zoë will still draft snippets when you ask, but she will not write them to your repository.
 

--- a/core-concepts/context-surfaces.md
+++ b/core-concepts/context-surfaces.md
@@ -127,18 +127,7 @@ When the toggle is on, Zoë's editing permissions match yours. The data model us
 
 #### Editing the production branch directly
 
-Asking Zoë to save a change while you're on the production branch is a separate, gated flow on top of the rules above. Zoë will only save edits on the production branch when **both** of the following are true:
-
-* You have `deploy_to_production` (so you are an **Admin** or **Develop** user).
-* The workspace's **Allow Edit Production** toggle is on.
-
-If either is missing, Zoë will refuse the edit and ask you to switch to a development branch.
-
-The Allow Edit Production toggle is on by default, and lives at:
-
-**Workspace Settings → Git → Allow Edit Production**
-
-Turn it off to enforce a branch-and-deploy workflow where every production change goes through a development branch followed by an explicit deploy step. Turn it on if you want users with `deploy_to_production` to be able to edit the production branch directly, including from chat.
+Asking Zoë to save a change on the production branch is gated by the same workspace setting that gates manual production edits in Context Manager: the **Allow Edit Production** toggle at **Workspace Settings → Git → Allow Edit Production** (on by default). Zoë will save on the production branch only if you are an **Admin** or **Develop** user and the toggle is on. Otherwise she'll refuse the edit and ask you to switch to a development branch. See [Work with branches safely](../zenlytic-ui/context_manager.md#work-with-branches-safely) for more on the toggle.
 
 See [User Roles](../zenlytic-ui/user_roles.md) for the full role and permission reference, and [Ask Zoë for Data Model Recommendations](../data-modeling/asking-zoe-for-recommendations.md) for concrete examples and the iteration playbook.
 

--- a/core-concepts/context-surfaces.md
+++ b/core-concepts/context-surfaces.md
@@ -97,7 +97,7 @@ Memories are retained for backward compatibility and will be migrated to skills 
 
 ## Letting Zoë edit context for you
 
-You can allow Zoë to directly make changes to your data model and tell her to save them, instead of pasting recommendations into [Context Manager](../zenlytic-ui/context_manager.md) yourself. When [this is on](#turn-it-on-or-off), Zoë can read, edit, validate, and commit changes to your repository on the branch you're currently working on.
+You can allow Zoë to make changes to your data model and tell her to save them, instead of pasting her recommendations into [Context Manager](../zenlytic-ui/context_manager.md) yourself. When [this is on](#turn-it-on-or-off), Zoë can read, edit, validate, and commit changes to your repository on the branch you're working on.
 
 The surfaces she can write to:
 
@@ -105,9 +105,9 @@ The surfaces she can write to:
 * The workspace `system_prompt.md`, for universal rules and shared domain knowledge
 * Workspace `skills/`, including `skills/<skill-name>/SKILL.md` and any supporting files
 
-Tell Zoë what you want to change ("add a measure for repeat purchase rate", "update the system prompt to default to net revenue", "create a skill for our fiscal calendar") and ask her to save it. She will draft the smallest correct edit, validate the data model with `validate_context`, commit and push the change with `save_context`, and run a quick sample query to confirm the edit works. If validation fails, she fixes the referenced files and validates again before saving, so no partial commits land.
+Tell Zoë what you want to change ("add a measure for repeat purchase rate", "update the system prompt to default to net revenue", "create a skill for our fiscal calendar") and ask her to save it. She'll draft the smallest correct edit, validate the data model with `validate_context`, commit and push the change with `save_context`, and run a quick sample query to confirm the edit works. If validation fails, she fixes the referenced files and validates again before saving, so no partial commits land.
 
-You can also keep Zoë in a review-only flow without saving anything. If you ask her to "audit the model", "find improvements", or "check whether you have enough context", she will inspect the data model and report recommendations instead of editing.
+If you'd rather have Zoë just review without editing, ask her to "audit the model", "find improvements", or "check whether you have enough context". She'll inspect the data model and report recommendations without saving anything.
 
 ### Turn it on or off
 
@@ -115,21 +115,21 @@ The feature is on by default for workspaces that have access to it. You can togg
 
 **Workspace Settings → Zoë → Context Editing**
 
-When the toggle is **on**, Zoë can save changes to your data model from chat, subject to the permission rules below. When the toggle is **off**, Zoë will still draft snippets when you ask, but she will not write them to your repository.
+When the toggle is **on**, Zoë can save changes to your data model from chat, subject to the permission rules below. When the toggle is **off**, Zoë will still draft snippets when you ask, but she won't write them to your repository.
 
 ### Zoë inherits your permissions
 
 When the toggle is on, Zoë's editing permissions match yours. The data model uses the same role-based rules whether you edit by hand in Context Manager or ask Zoë to do it from chat:
 
-* If you are an **Explore**, **View**, or **Restricted** user (or any role without `data_model_edit`), Zoë cannot edit the data model. She will draft recommendations instead.
-* If you are **Develop**, **Develop without Deploy**, or **Admin**, Zoë can edit the data model on the branch you are currently on, as long as that branch is not the production branch.
+* If you are an **Explore**, **View**, or **Restricted** user (or any role without `data_model_edit`), Zoë cannot edit the data model. She'll draft recommendations instead.
+* If you are **Develop**, **Develop without Deploy**, or **Admin**, Zoë can edit the data model on the branch you're currently on, as long as that branch isn't the production branch.
 * Only workspace **Admins** and users with the **Develop** role can deploy a development branch to the production branch. Deployment happens in [Context Manager](../zenlytic-ui/context_manager.md), not from chat.
+
+See [User Roles](../zenlytic-ui/user_roles.md) for the full role and permission reference.
 
 #### Editing the production branch directly
 
 You can allow Zoë to save edits on the production branch by turning on the **Allow Edit Production** toggle at **Workspace Settings → Git → Allow Edit Production**. With the toggle on, Zoë will save changes on the production branch for **Admin** and **Develop** users. With it off, she'll refuse production edits and ask you to switch to a development branch. The toggle is on by default and uses the same setting that controls manual production edits in Context Manager. See [Work with branches safely](../zenlytic-ui/context_manager.md#work-with-branches-safely) for more on the toggle.
-
-See [User Roles](../zenlytic-ui/user_roles.md) for the full role and permission reference, and [Ask Zoë for Data Model Recommendations](../data-modeling/asking-zoe-for-recommendations.md) for concrete examples and the iteration playbook.
 
 ## Related pages
 

--- a/data-modeling/asking-zoe-for-recommendations.md
+++ b/data-modeling/asking-zoe-for-recommendations.md
@@ -1,6 +1,6 @@
 # Ask Zoë for Data Model Recommendations
 
-You don't have to author your data model alone. Zoë can recommend changes directly from chat: new measures, new dimensions, new relationships, calculation logic, view and field documentation, workspace skills, updates to the `system_prompt.md`, or restructuring something that isn't answering questions well. If you've allowed her to, she can also make those changes for you and save them to your repository on the current branch.
+You don't have to author your data model alone. Zoë can recommend changes directly from chat: new measures, new dimensions, new relationships, calculation logic, view and field documentation, workspace skills, updates to the `system_prompt.md`, or restructuring something that isn't answering questions well. [If you've allowed her to](#turning-context-editing-on-or-off), she can also make those changes for you and save them to your repository on the current branch.
 
 Ask in plain English. Either let Zoë draft a snippet for you to paste in [Context Manager](../zenlytic-ui/context_manager.md), or tell her to make the change for you.
 
@@ -75,7 +75,7 @@ If Zoë's edits are turned off, or you'd rather review the change before it land
 4. If the change is significant, deploy to production when you're ready.
 5. Re-ask your original question to confirm the change works end-to-end.
 
-## Turning Zoë's edits on or off
+## Turning context editing on or off
 
 Zoë's edits are on by default for workspaces that have access to the feature. You can toggle the behavior per workspace at:
 

--- a/data-modeling/asking-zoe-for-recommendations.md
+++ b/data-modeling/asking-zoe-for-recommendations.md
@@ -103,7 +103,7 @@ If either is missing, Zoë will refuse the edit and ask you to switch to a devel
 
 The Allow Edit Production toggle is on by default, and lives at:
 
-**Workspace Settings → Git Settings → Allow Edit Production**
+**Workspace Settings → Git → Allow Edit Production**
 
 Turn it off to enforce a branch-and-deploy workflow where every production change goes through a development branch followed by an explicit deploy step. Turn it on if you want users with `deploy_to_production` to be able to edit the production branch directly, including from chat.
 

--- a/data-modeling/asking-zoe-for-recommendations.md
+++ b/data-modeling/asking-zoe-for-recommendations.md
@@ -90,7 +90,7 @@ When edits are turned on, Zoë's editing permissions match your own. The data mo
 
 * If you are an **Explore**, **View**, or **Restricted** user (or any role without `data_model_edit`), Zoë cannot edit the data model. She will draft recommendations and explain that you or a workspace admin needs to apply them.
 * If you are **Develop**, **Develop without Deploy**, or **Admin**, Zoë can edit the data model on the branch you are currently on, as long as that branch is not the production branch.
-* Only workspace **Admins** and users with the **Develop** role (which carries `deploy_to_production`) can deploy a development branch to the production branch. Deployment happens in [Context Manager](../zenlytic-ui/context_manager.md), not from chat.
+* Only workspace **Admins** and users with the **Develop** role can deploy a development branch to the production branch. Deployment happens in [Context Manager](../zenlytic-ui/context_manager.md), not from chat.
 
 ### Editing the production branch directly
 

--- a/data-modeling/asking-zoe-for-recommendations.md
+++ b/data-modeling/asking-zoe-for-recommendations.md
@@ -79,7 +79,7 @@ If Zoë's edits are turned off, or you'd rather review the change before it land
 
 Zoë's edits are on by default for workspaces that have access to the feature. You can toggle the behavior per workspace at:
 
-**Workspace Settings → Chat Settings → Context Editing**
+**Workspace Settings → Zoë → Context Editing**
 
 * When the toggle is **on**, Zoë can save changes to your data model from chat, subject to the permission rules below.
 * When the toggle is **off**, Zoë will still draft snippets when you ask, but she will not write them to your repository.

--- a/data-modeling/asking-zoe-for-recommendations.md
+++ b/data-modeling/asking-zoe-for-recommendations.md
@@ -1,8 +1,8 @@
 # Ask Zoë for Data Model Recommendations
 
-You don't have to author your data model alone. Zoë can recommend specific changes directly from chat — new measures, new dimensions, new relationships, calculation logic, or how to restructure something that isn't answering questions the way you'd like.
+You don't have to author your data model alone. Zoë can recommend — and, when you ask her to, **apply** — specific changes to your context directly from chat. That includes new measures, new dimensions, new relationships, calculation logic, view and field documentation, workspace skills, the `system_prompt.md`, or restructuring something that isn't answering questions the way you'd like.
 
-This is often the fastest way to extend your model. Ask in plain English, take Zoë's recommendation, and apply it in [Context Manager](../zenlytic-ui/context_manager.md).
+This is often the fastest way to extend your model. Ask in plain English, and either let Zoë make the change for you on the current branch or take her recommendation and apply it yourself in [Context Manager](../zenlytic-ui/context_manager.md).
 
 ## When to ask Zoë instead of authoring from scratch
 
@@ -14,16 +14,45 @@ Good questions to bring to Zoë:
 * **"Why did you pick the wrong field?"** — Zoë can often diagnose why she chose the wrong field and recommend adding a `synonym`, `zoe_description`, or a new measure to prevent it next time. See also [Fixing Zoë's Mistakes](../core-concepts/fixing-zoes-mistakes.md).
 * **"What should I add to this view to make it more useful?"** — Zoë can look at a view and recommend missing measures, synonyms, or descriptions.
 
-## What Zoë gives you back
+## Two modes: recommend vs. apply
 
-Depending on the question, Zoë will return one or more of:
+Zoë operates in one of two modes depending on what you ask for and what permissions are in play.
+
+### Recommend mode
+
+In recommend mode Zoë drafts the change and hands it back to you. Use this when you're exploring options, when you want to review the change before it lands, or when context editing isn't available for your role or workspace. Depending on the question, she'll return one or more of:
 
 * **A YAML snippet** to paste into the relevant view, model, or topic file
 * **A plain-English explanation** of what the change does and why
 * **A note** about where the change should go (view `description` vs. field `zoe_description` vs. the system prompt) — see [Context Surfaces](../core-concepts/context-surfaces.md) for the decision framework
 * **Follow-up questions** if she needs more detail (e.g., "Do you want this measure to exclude returned orders?")
 
-Zoë's recommendations are suggestions, not automatic changes — she doesn't edit your data model files directly. You stay in control of what actually ships.
+You apply the recommendation in [Context Manager](../zenlytic-ui/context_manager.md).
+
+### Apply mode
+
+When you tell Zoë to make the change ("add the measure", "fix the join", "update the system prompt to say…"), she'll do it on the branch you're working on. The full workflow:
+
+1. **Read** the current state of the relevant files.
+2. **Draft** the smallest correct edit — a new field, an updated `zoe_description`, a new skill, etc.
+3. **Validate** the data model with `validate_context` so YAML errors are caught before anything is committed.
+4. **Save** the change to your repository with `save_context`, which commits and pushes on the current branch.
+5. **Sample-query** the change for new or modified measures, dimensions, or dimension groups, so you can sanity-check the result.
+6. **Report back** with what changed, the commit, and a suggestion to re-ask the original question.
+
+If validation fails Zoë reads the error, fixes the referenced files, and validates again before saving. No partial commits land.
+
+The surfaces Zoë can edit in apply mode:
+
+* **Data model YAML** under `views/`, `models/`, `topics/`, and `dashboards/`, plus `zenlytic_project.yml`
+* **The workspace `system_prompt.md`** for shared, always-on rules
+* **Workspace `skills/`** — `skills/<skill-name>/SKILL.md` plus its supporting files
+
+She follows the same authoring rules a human editor would: flat `fields:` lists, valid measure patterns, conservative use of `searchable: true`, and `zoe_description` rather than `description` for agent-only guidance. See [Context Surfaces](../core-concepts/context-surfaces.md) for the full decision tree.
+
+### Review-only requests
+
+If you ask Zoë to "audit the model", "recommend changes", or "check whether she has enough context", she stays in recommend mode by default — inspecting the current data model and reporting targeted recommendations without editing or committing. She'll only switch to apply mode when you explicitly ask her to make the changes.
 
 ## Example: adding a measure
 
@@ -53,21 +82,46 @@ You ask:
 
 Zoë will inspect both views and recommend a [relationship](relationships.md) block for the model file with the right `relationship` cardinality and `sql_on` condition, plus a note if the join risks fan-out.
 
-## Applying the recommendation
+## Applying a recommendation yourself
+
+If you're working in recommend mode (or you want to review before saving), apply the snippet manually:
 
 1. Open [Context Manager](../zenlytic-ui/context_manager.md).
-2. Navigate to the file Zoë named (view, model, or topic).
+2. Navigate to the file Zoë named (view, model, topic, system prompt, or skill).
 3. Paste the snippet in the right place and save.
 4. If the change is significant, deploy to production when you're ready.
 5. Re-ask your original question to confirm the change works end-to-end.
 
+## Enabling or disabling Zoë's edits
+
+Apply mode is on by default for workspaces that have access to it, but you can turn it on or off per workspace:
+
+**Workspace Settings → Chat Settings → Context Editing**
+
+When the toggle is **off**, Zoë stays in recommend mode no matter what you ask her — she'll still draft snippets, but she won't write them to your repository.
+
+A few additional rules govern when apply mode is available even with the toggle on:
+
+* **Permissions:** Zoë needs you to have `develop_without_deploy` (or higher) on the workspace. Below that, she behaves as read-only and will only recommend.
+* **Branches:** edits on a non-production branch are always allowed for users with `develop_without_deploy`. Edits on the production branch additionally require `deploy_to_production` permission **and** the workspace's "Allow editing production" setting to be enabled.
+* **Validation:** if the change is in data model YAML and the model is invalid, Zoë won't save until she's fixed the referenced files. She'll tell you what failed.
+
+## What Zoë won't do
+
+Even in apply mode, Zoë holds the line on a few things:
+
+* **Edit production when blocked.** If you don't have `deploy_to_production` or "Allow editing production" is off, Zoë will refuse production edits and suggest switching to a development branch or asking a workspace admin.
+* **Edit without `data_model_edit`.** If your role doesn't have data-model edit access, Zoë will recommend the change and tell you who can apply it.
+* **Recommend Memories or Topics for new context.** Memories are legacy and being retired in favor of Skills. Topics are legacy/backwards-compatibility only. Zoë will route new context to view/field properties, skills, or the system prompt instead.
+* **Rewrite a whole file when a small edit will do.** Zoë makes the smallest correct change to fix the issue you reported, rather than restructuring on speculation.
+
 ## Iterate based on what goes wrong
 
-Zoë's recommendations aren't always perfect on the first try. If her suggestion doesn't produce the right answer when you test it, tell her — "that measure gave the wrong number, the denominator should exclude internal test accounts" — and she'll refine the recommendation. This is the same iterative philosophy the whole data model is built on: add context to fix the specific error you observed, rather than trying to anticipate every edge case up front. See [Progressive Enrichment](../core-concepts/progressive-enrichment.md) for the broader playbook.
+Zoë's edits and recommendations aren't always perfect on the first try. If a change doesn't produce the right answer when you test it, tell her — "that measure gave the wrong number, the denominator should exclude internal test accounts" — and she'll refine, re-validate, and (in apply mode) commit the fix. This is the same iterative philosophy the whole data model is built on: add context to fix the specific error you observed, rather than trying to anticipate every edge case up front. See [Progressive Enrichment](../core-concepts/progressive-enrichment.md) for the broader playbook.
 
 ## Related
 
-* [Context Manager](../zenlytic-ui/context_manager.md) — where you apply Zoë's recommendations
-* [Context Surfaces](../core-concepts/context-surfaces.md) — when to use `description`, `zoe_description`, synonyms, or the system prompt
+* [Context Manager](../zenlytic-ui/context_manager.md) — where you apply Zoë's recommendations or review her commits
+* [Context Surfaces](../core-concepts/context-surfaces.md) — when to use `description`, `zoe_description`, synonyms, or the system prompt; also covers the enable/disable toggle and the surfaces Zoë can edit
 * [Fixing Zoë's Mistakes](../core-concepts/fixing-zoes-mistakes.md) — diagnostic flow when Zoë gives a wrong answer
 * [Measures](measure.md) — valid/invalid aggregation patterns for measure SQL

--- a/data-modeling/asking-zoe-for-recommendations.md
+++ b/data-modeling/asking-zoe-for-recommendations.md
@@ -1,8 +1,8 @@
 # Ask Zoë for Data Model Recommendations
 
-You don't have to author your data model alone. Zoë can recommend — and, when you ask her to, **apply** — specific changes to your context directly from chat. That includes new measures, new dimensions, new relationships, calculation logic, view and field documentation, workspace skills, the `system_prompt.md`, or restructuring something that isn't answering questions the way you'd like.
+You don't have to author your data model alone. Zoë can recommend specific changes directly from chat, and if you've allowed her to, she can also make those changes for you and save them to your repository. The catalog of things she can help with is the same either way: new measures, new dimensions, new relationships, calculation logic, view and field documentation, workspace skills, the `system_prompt.md`, or restructuring something that isn't answering questions the way you'd like.
 
-This is often the fastest way to extend your model. Ask in plain English, and either let Zoë make the change for you on the current branch or take her recommendation and apply it yourself in [Context Manager](../zenlytic-ui/context_manager.md).
+Ask in plain English. Either let Zoë draft a snippet for you to paste in [Context Manager](../zenlytic-ui/context_manager.md), or tell her to make the change for you on the current branch.
 
 ## When to ask Zoë instead of authoring from scratch
 
@@ -14,45 +14,28 @@ Good questions to bring to Zoë:
 * **"Why did you pick the wrong field?"** — Zoë can often diagnose why she chose the wrong field and recommend adding a `synonym`, `zoe_description`, or a new measure to prevent it next time. See also [Fixing Zoë's Mistakes](../core-concepts/fixing-zoes-mistakes.md).
 * **"What should I add to this view to make it more useful?"** — Zoë can look at a view and recommend missing measures, synonyms, or descriptions.
 
-## Two modes: recommend vs. apply
+## Letting Zoë make the change for you
 
-Zoë operates in one of two modes depending on what you ask for and what permissions are in play.
+You can allow Zoë to directly make changes to your data model and tell her to save them. When this is on, you can ask her to "add the measure", "fix the join", "update the system prompt to say...", or "create a skill for our fiscal calendar", and she will:
 
-### Recommend mode
+1. Read the current state of the relevant files.
+2. Draft the smallest correct edit, such as a new field, an updated `zoe_description`, or a new skill.
+3. Validate the data model with `validate_context` so YAML errors are caught before anything is committed.
+4. Save the change to your repository with `save_context`, which commits and pushes on the current branch.
+5. Run a sample query against any new or modified measure, dimension, or dimension group, so you can sanity-check the result.
+6. Report back with what changed and suggest you re-ask the original question.
 
-In recommend mode Zoë drafts the change and hands it back to you. Use this when you're exploring options, when you want to review the change before it lands, or when context editing isn't available for your role or workspace. Depending on the question, she'll return one or more of:
+If validation fails, Zoë reads the error, fixes the referenced files, and validates again before saving, so no partial commits land.
 
-* **A YAML snippet** to paste into the relevant view, model, or topic file
-* **A plain-English explanation** of what the change does and why
-* **A note** about where the change should go (view `description` vs. field `zoe_description` vs. the system prompt) — see [Context Surfaces](../core-concepts/context-surfaces.md) for the decision framework
-* **Follow-up questions** if she needs more detail (e.g., "Do you want this measure to exclude returned orders?")
+The surfaces Zoë can edit:
 
-You apply the recommendation in [Context Manager](../zenlytic-ui/context_manager.md).
-
-### Apply mode
-
-When you tell Zoë to make the change ("add the measure", "fix the join", "update the system prompt to say…"), she'll do it on the branch you're working on. The full workflow:
-
-1. **Read** the current state of the relevant files.
-2. **Draft** the smallest correct edit — a new field, an updated `zoe_description`, a new skill, etc.
-3. **Validate** the data model with `validate_context` so YAML errors are caught before anything is committed.
-4. **Save** the change to your repository with `save_context`, which commits and pushes on the current branch.
-5. **Sample-query** the change for new or modified measures, dimensions, or dimension groups, so you can sanity-check the result.
-6. **Report back** with what changed, the commit, and a suggestion to re-ask the original question.
-
-If validation fails Zoë reads the error, fixes the referenced files, and validates again before saving. No partial commits land.
-
-The surfaces Zoë can edit in apply mode:
-
-* **Data model YAML** under `views/`, `models/`, `topics/`, and `dashboards/`, plus `zenlytic_project.yml`
-* **The workspace `system_prompt.md`** for shared, always-on rules
-* **Workspace `skills/`** — `skills/<skill-name>/SKILL.md` plus its supporting files
+* Data model YAML under `views/`, `models/`, `topics/`, and `dashboards/`, plus `zenlytic_project.yml`
+* The workspace `system_prompt.md`, for shared, always-on rules
+* Workspace `skills/`, including `skills/<skill-name>/SKILL.md` and any supporting files
 
 She follows the same authoring rules a human editor would: flat `fields:` lists, valid measure patterns, conservative use of `searchable: true`, and `zoe_description` rather than `description` for agent-only guidance. See [Context Surfaces](../core-concepts/context-surfaces.md) for the full decision tree.
 
-### Review-only requests
-
-If you ask Zoë to "audit the model", "recommend changes", or "check whether she has enough context", she stays in recommend mode by default — inspecting the current data model and reporting targeted recommendations without editing or committing. She'll only switch to apply mode when you explicitly ask her to make the changes.
+If you ask Zoë to "audit the model", "recommend changes", or "check whether she has enough context", she will inspect the data model and report findings without editing or committing. She only saves when you explicitly ask her to make the change.
 
 ## Example: adding a measure
 
@@ -84,7 +67,7 @@ Zoë will inspect both views and recommend a [relationship](relationships.md) bl
 
 ## Applying a recommendation yourself
 
-If you're working in recommend mode (or you want to review before saving), apply the snippet manually:
+If Zoë's edits are turned off, or you'd rather review the change before it lands, apply her snippet by hand:
 
 1. Open [Context Manager](../zenlytic-ui/context_manager.md).
 2. Navigate to the file Zoë named (view, model, topic, system prompt, or skill).
@@ -92,36 +75,42 @@ If you're working in recommend mode (or you want to review before saving), apply
 4. If the change is significant, deploy to production when you're ready.
 5. Re-ask your original question to confirm the change works end-to-end.
 
-## Enabling or disabling Zoë's edits
+## Turning Zoë's edits on or off
 
-Apply mode is on by default for workspaces that have access to it, but you can turn it on or off per workspace:
+Zoë's edits are on by default for workspaces that have access to the feature. You can toggle the behavior per workspace at:
 
 **Workspace Settings → Chat Settings → Context Editing**
 
-When the toggle is **off**, Zoë stays in recommend mode no matter what you ask her — she'll still draft snippets, but she won't write them to your repository.
+* When the toggle is **on**, Zoë can save changes to your data model from chat, subject to the permission rules below.
+* When the toggle is **off**, Zoë will still draft snippets when you ask, but she will not write them to your repository.
 
-A few additional rules govern when apply mode is available even with the toggle on:
+## Zoë inherits your permissions
 
-* **Permissions:** Zoë needs you to have `develop_without_deploy` (or higher) on the workspace. Below that, she behaves as read-only and will only recommend.
-* **Branches:** edits on a non-production branch are always allowed for users with `develop_without_deploy`. Edits on the production branch additionally require `deploy_to_production` permission **and** the workspace's "Allow editing production" setting to be enabled.
-* **Validation:** if the change is in data model YAML and the model is invalid, Zoë won't save until she's fixed the referenced files. She'll tell you what failed.
+When edits are turned on, Zoë's editing permissions match your own. The data model is governed by the same role-based rules whether you edit by hand in Context Manager or ask Zoë to do it from chat:
+
+* If you are an **Explore** or **View** user (or any role without `data_model_edit`), Zoë cannot edit the data model. She will draft recommendations and explain that you or a workspace admin needs to apply them.
+* If you are **Develop**, **Develop without Deploy**, or **Admin**, Zoë can edit the data model on the branch you are currently on.
+* Only workspace **Admins** and users with the **Develop** role (which carries `deploy_to_production`) can deploy a development branch to the production branch. Direct edits to the production branch from chat additionally require the workspace's "Allow editing production" setting to be enabled; without it, Zoë will refuse and ask you to switch to a development branch.
+
+See [User Roles](../zenlytic-ui/user_roles.md) for the full role and permission reference.
 
 ## What Zoë won't do
 
-Even in apply mode, Zoë holds the line on a few things:
+Even with edits turned on, Zoë holds the line on a few things:
 
-* **Edit production when blocked.** If you don't have `deploy_to_production` or "Allow editing production" is off, Zoë will refuse production edits and suggest switching to a development branch or asking a workspace admin.
-* **Edit without `data_model_edit`.** If your role doesn't have data-model edit access, Zoë will recommend the change and tell you who can apply it.
-* **Recommend Memories or Topics for new context.** Memories are legacy and being retired in favor of Skills. Topics are legacy/backwards-compatibility only. Zoë will route new context to view/field properties, skills, or the system prompt instead.
-* **Rewrite a whole file when a small edit will do.** Zoë makes the smallest correct change to fix the issue you reported, rather than restructuring on speculation.
+* Edit production when blocked. If you don't have `deploy_to_production`, or "Allow editing production" is off, Zoë will refuse production edits and suggest switching to a development branch or asking a workspace admin.
+* Edit without `data_model_edit`. If your role doesn't include data model edit access, Zoë will recommend the change and tell you who can apply it.
+* Recommend Memories or Topics for new context. Memories are legacy and being retired in favor of Skills. Topics are legacy/backwards-compatibility only. Zoë will route new context to view and field properties, skills, or the system prompt instead.
+* Rewrite a whole file when a small edit will do. Zoë makes the smallest correct change to fix the issue you reported, rather than restructuring on speculation.
 
 ## Iterate based on what goes wrong
 
-Zoë's edits and recommendations aren't always perfect on the first try. If a change doesn't produce the right answer when you test it, tell her — "that measure gave the wrong number, the denominator should exclude internal test accounts" — and she'll refine, re-validate, and (in apply mode) commit the fix. This is the same iterative philosophy the whole data model is built on: add context to fix the specific error you observed, rather than trying to anticipate every edge case up front. See [Progressive Enrichment](../core-concepts/progressive-enrichment.md) for the broader playbook.
+Zoë's edits and recommendations aren't always perfect on the first try. If a change doesn't produce the right answer when you test it, tell her (for example, "that measure gave the wrong number, the denominator should exclude internal test accounts") and she'll refine, re-validate, and, when edits are on, commit the fix. This is the same iterative philosophy the whole data model is built on: add context to fix the specific error you observed, rather than trying to anticipate every edge case up front. See [Progressive Enrichment](../core-concepts/progressive-enrichment.md) for the broader playbook.
 
 ## Related
 
-* [Context Manager](../zenlytic-ui/context_manager.md) — where you apply Zoë's recommendations or review her commits
-* [Context Surfaces](../core-concepts/context-surfaces.md) — when to use `description`, `zoe_description`, synonyms, or the system prompt; also covers the enable/disable toggle and the surfaces Zoë can edit
+* [Context Manager](../zenlytic-ui/context_manager.md): where you apply Zoë's recommendations or review her commits
+* [Context Surfaces](../core-concepts/context-surfaces.md): when to use `description`, `zoe_description`, synonyms, or the system prompt; also covers the enable/disable toggle and the surfaces Zoë can edit
+* [User Roles](../zenlytic-ui/user_roles.md): the role and permission reference Zoë inherits from
 * [Fixing Zoë's Mistakes](../core-concepts/fixing-zoes-mistakes.md) — diagnostic flow when Zoë gives a wrong answer
 * [Measures](measure.md) — valid/invalid aggregation patterns for measure SQL

--- a/data-modeling/asking-zoe-for-recommendations.md
+++ b/data-modeling/asking-zoe-for-recommendations.md
@@ -1,6 +1,6 @@
 # Ask Zoë for Data Model Recommendations
 
-You don't have to author your data model alone. Zoë can recommend changes directly from chat: new measures, new dimensions, new relationships, calculation logic, view and field documentation, workspace skills, updates to the `system_prompt.md`, or restructuring something that isn't answering questions well. [If you've allowed her to](#turning-context-editing-on-or-off), she can also make those changes for you and save them to your repository on the current branch.
+You don't have to author your data model alone. Zoë can recommend changes directly from chat: new measures, new dimensions, new relationships, calculation logic, view and field documentation, workspace skills, updates to the system prompt, or restructuring something that isn't answering questions well. [If you've allowed her to](#turning-context-editing-on-or-off), she can also make those changes for you and save them to your repository on the current branch.
 
 Ask in plain English. Either let Zoë draft a snippet for you to paste in [Context Manager](../zenlytic-ui/context_manager.md), or tell her to make the change for you.
 
@@ -20,8 +20,8 @@ With Zoë's edits turned on for your workspace, you can ask her to "add the meas
 
 1. Read the current state of the relevant files.
 2. Draft the smallest correct edit, such as a new field, an updated `zoe_description`, or a new skill.
-3. Validate the data model with `validate_context` so YAML errors are caught before anything is committed.
-4. Save the change to your repository with `save_context`, which commits and pushes on the current branch.
+3. Validate the data model so YAML errors are caught before anything is committed.
+4. Commit and push the change to your repository on the current branch.
 5. Run a sample query against any new or modified measure, dimension, or dimension group, so you can sanity-check the result.
 6. Report back with what changed and suggest you re-ask the original question.
 
@@ -30,7 +30,7 @@ If validation fails, Zoë reads the error, fixes the referenced files, and valid
 The surfaces Zoë can edit:
 
 * Data model YAML under `views/`, `models/`, `topics/`, and `dashboards/`, plus `zenlytic_project.yml`
-* The workspace `system_prompt.md`, for shared, always-on rules
+* The workspace system prompt, for shared, always-on rules
 * Workspace `skills/`, including `skills/<skill-name>/SKILL.md` and any supporting files
 
 She follows the same authoring rules a human editor would: flat `fields:` lists, valid measure patterns, conservative use of `searchable: true`, and `zoe_description` rather than `description` for agent-only guidance. See [Context Surfaces](../core-concepts/context-surfaces.md) for the full decision tree.

--- a/data-modeling/asking-zoe-for-recommendations.md
+++ b/data-modeling/asking-zoe-for-recommendations.md
@@ -1,8 +1,8 @@
 # Ask Zoë for Data Model Recommendations
 
-You don't have to author your data model alone. Zoë can recommend specific changes directly from chat, and if you've allowed her to, she can also make those changes for you and save them to your repository. The catalog of things she can help with is the same either way: new measures, new dimensions, new relationships, calculation logic, view and field documentation, workspace skills, the `system_prompt.md`, or restructuring something that isn't answering questions the way you'd like.
+You don't have to author your data model alone. Zoë can recommend changes directly from chat: new measures, new dimensions, new relationships, calculation logic, view and field documentation, workspace skills, updates to the `system_prompt.md`, or restructuring something that isn't answering questions well. If you've allowed her to, she can also make those changes for you and save them to your repository on the current branch.
 
-Ask in plain English. Either let Zoë draft a snippet for you to paste in [Context Manager](../zenlytic-ui/context_manager.md), or tell her to make the change for you on the current branch.
+Ask in plain English. Either let Zoë draft a snippet for you to paste in [Context Manager](../zenlytic-ui/context_manager.md), or tell her to make the change for you.
 
 ## When to ask Zoë instead of authoring from scratch
 
@@ -16,7 +16,7 @@ Good questions to bring to Zoë:
 
 ## Letting Zoë make the change for you
 
-You can allow Zoë to directly make changes to your data model and tell her to save them. When this is on, you can ask her to "add the measure", "fix the join", "update the system prompt to say...", or "create a skill for our fiscal calendar", and she will:
+With Zoë's edits turned on for your workspace, you can ask her to "add the measure", "fix the join", "update the system prompt to say...", or "create a skill for our fiscal calendar", and she'll:
 
 1. Read the current state of the relevant files.
 2. Draft the smallest correct edit, such as a new field, an updated `zoe_description`, or a new skill.
@@ -35,7 +35,7 @@ The surfaces Zoë can edit:
 
 She follows the same authoring rules a human editor would: flat `fields:` lists, valid measure patterns, conservative use of `searchable: true`, and `zoe_description` rather than `description` for agent-only guidance. See [Context Surfaces](../core-concepts/context-surfaces.md) for the full decision tree.
 
-If you ask Zoë to "audit the model", "recommend changes", or "check whether she has enough context", she will inspect the data model and report findings without editing or committing. She only saves when you explicitly ask her to make the change.
+If you'd rather have Zoë just review without editing, ask her to "audit the model", "recommend changes", or "check whether she has enough context". She'll inspect the data model and report findings without saving anything, and only commits when you explicitly ask her to make the change.
 
 ## Example: adding a measure
 
@@ -88,28 +88,27 @@ Zoë's edits are on by default for workspaces that have access to the feature. Y
 
 When edits are turned on, Zoë's editing permissions match your own. The data model is governed by the same role-based rules whether you edit by hand in Context Manager or ask Zoë to do it from chat:
 
-* If you are an **Explore**, **View**, or **Restricted** user (or any role without `data_model_edit`), Zoë cannot edit the data model. She will draft recommendations and explain that you or a workspace admin needs to apply them.
-* If you are **Develop**, **Develop without Deploy**, or **Admin**, Zoë can edit the data model on the branch you are currently on, as long as that branch is not the production branch.
+* If you are an **Explore**, **View**, or **Restricted** user (or any role without `data_model_edit`), Zoë cannot edit the data model. She'll draft recommendations and explain that you or a workspace admin needs to apply them.
+* If you are **Develop**, **Develop without Deploy**, or **Admin**, Zoë can edit the data model on the branch you're currently on, as long as that branch isn't the production branch.
 * Only workspace **Admins** and users with the **Develop** role can deploy a development branch to the production branch. Deployment happens in [Context Manager](../zenlytic-ui/context_manager.md), not from chat.
+
+See [User Roles](../zenlytic-ui/user_roles.md) for the full role and permission reference.
 
 ### Editing the production branch directly
 
 You can allow Zoë to save edits on the production branch by turning on the **Allow Edit Production** toggle at **Workspace Settings → Git → Allow Edit Production**. With the toggle on, Zoë will save changes on the production branch for **Admin** and **Develop** users. With it off, she'll refuse production edits and ask you to switch to a development branch. The toggle is on by default and uses the same setting that controls manual production edits in Context Manager. See [Work with branches safely](../zenlytic-ui/context_manager.md#work-with-branches-safely) for more on the toggle.
 
-See [User Roles](../zenlytic-ui/user_roles.md) for the full role and permission reference.
-
 ## What Zoë won't do
 
 Even with edits turned on, Zoë holds the line on a few things:
 
-* Edit production when blocked. If you don't have `deploy_to_production`, or "Allow editing production" is off, Zoë will refuse production edits and suggest switching to a development branch or asking a workspace admin.
-* Edit without `data_model_edit`. If your role doesn't include data model edit access, Zoë will recommend the change and tell you who can apply it.
-* Recommend Memories or Topics for new context. Memories are legacy and being retired in favor of Skills. Topics are legacy/backwards-compatibility only. Zoë will route new context to view and field properties, skills, or the system prompt instead.
+* Save changes she isn't allowed to. If your role lacks `data_model_edit`, or you're on the production branch without the right permission and toggle, Zoë will recommend the change and tell you who can apply it instead.
+* Recommend Memories or Topics for new context. Memories are legacy and being retired in favor of Skills. Topics are legacy and kept only for backwards compatibility. Zoë routes new context to view and field properties, skills, or the system prompt instead.
 * Rewrite a whole file when a small edit will do. Zoë makes the smallest correct change to fix the issue you reported, rather than restructuring on speculation.
 
 ## Iterate based on what goes wrong
 
-Zoë's edits and recommendations aren't always perfect on the first try. If a change doesn't produce the right answer when you test it, tell her (for example, "that measure gave the wrong number, the denominator should exclude internal test accounts") and she'll refine, re-validate, and, when edits are on, commit the fix. This is the same iterative philosophy the whole data model is built on: add context to fix the specific error you observed, rather than trying to anticipate every edge case up front. See [Progressive Enrichment](../core-concepts/progressive-enrichment.md) for the broader playbook.
+Zoë's edits and recommendations aren't always perfect on the first try. If a change doesn't produce the right answer when you test it, tell her what's wrong (for example, "that measure gave the wrong number, the denominator should exclude internal test accounts"). She'll refine the change, re-validate it, and commit the fix when you ask her to. This is the same iterative philosophy the whole data model is built on: add context to fix the specific error you observed, rather than trying to anticipate every edge case up front. See [Progressive Enrichment](../core-concepts/progressive-enrichment.md) for the broader playbook.
 
 ## Related
 

--- a/data-modeling/asking-zoe-for-recommendations.md
+++ b/data-modeling/asking-zoe-for-recommendations.md
@@ -94,18 +94,7 @@ When edits are turned on, Zoë's editing permissions match your own. The data mo
 
 ### Editing the production branch directly
 
-Asking Zoë to save a change while you're on the production branch is a separate, gated flow on top of the rules above. Zoë will only save edits on the production branch when **both** of the following are true:
-
-* You have `deploy_to_production` (so you are an **Admin** or **Develop** user).
-* The workspace's **Allow Edit Production** toggle is on.
-
-If either is missing, Zoë will refuse the edit and ask you to switch to a development branch.
-
-The Allow Edit Production toggle is on by default, and lives at:
-
-**Workspace Settings → Git → Allow Edit Production**
-
-Turn it off to enforce a branch-and-deploy workflow where every production change goes through a development branch followed by an explicit deploy step. Turn it on if you want users with `deploy_to_production` to be able to edit the production branch directly, including from chat.
+Asking Zoë to save a change on the production branch is gated by the same workspace setting that gates manual production edits in Context Manager: the **Allow Edit Production** toggle at **Workspace Settings → Git → Allow Edit Production** (on by default). Zoë will save on the production branch only if you are an **Admin** or **Develop** user and the toggle is on. Otherwise she'll refuse the edit and ask you to switch to a development branch. See [Work with branches safely](../zenlytic-ui/context_manager.md#work-with-branches-safely) for more on the toggle.
 
 See [User Roles](../zenlytic-ui/user_roles.md) for the full role and permission reference.
 

--- a/data-modeling/asking-zoe-for-recommendations.md
+++ b/data-modeling/asking-zoe-for-recommendations.md
@@ -89,8 +89,23 @@ Zoë's edits are on by default for workspaces that have access to the feature. Y
 When edits are turned on, Zoë's editing permissions match your own. The data model is governed by the same role-based rules whether you edit by hand in Context Manager or ask Zoë to do it from chat:
 
 * If you are an **Explore** or **View** user (or any role without `data_model_edit`), Zoë cannot edit the data model. She will draft recommendations and explain that you or a workspace admin needs to apply them.
-* If you are **Develop**, **Develop without Deploy**, or **Admin**, Zoë can edit the data model on the branch you are currently on.
-* Only workspace **Admins** and users with the **Develop** role (which carries `deploy_to_production`) can deploy a development branch to the production branch. Direct edits to the production branch from chat additionally require the workspace's "Allow editing production" setting to be enabled; without it, Zoë will refuse and ask you to switch to a development branch.
+* If you are **Develop**, **Develop without Deploy**, or **Admin**, Zoë can edit the data model on the branch you are currently on, as long as that branch is not the production branch.
+* Only workspace **Admins** and users with the **Develop** role (which carries `deploy_to_production`) can deploy a development branch to the production branch. Deployment happens in [Context Manager](../zenlytic-ui/context_manager.md), not from chat.
+
+### Editing the production branch directly
+
+Asking Zoë to save a change while you're on the production branch is a separate, gated flow on top of the rules above. Zoë will only save edits on the production branch when **both** of the following are true:
+
+* You have `deploy_to_production` (so you are an **Admin** or **Develop** user).
+* The workspace's **Allow Edit Production** toggle is on.
+
+If either is missing, Zoë will refuse the edit and ask you to switch to a development branch.
+
+The Allow Edit Production toggle is on by default, and lives at:
+
+**Workspace Settings → Git Settings → Allow Edit Production**
+
+Turn it off to enforce a branch-and-deploy workflow where every production change goes through a development branch followed by an explicit deploy step. Turn it on if you want users with `deploy_to_production` to be able to edit the production branch directly, including from chat.
 
 See [User Roles](../zenlytic-ui/user_roles.md) for the full role and permission reference.
 

--- a/data-modeling/asking-zoe-for-recommendations.md
+++ b/data-modeling/asking-zoe-for-recommendations.md
@@ -88,7 +88,7 @@ Zoë's edits are on by default for workspaces that have access to the feature. Y
 
 When edits are turned on, Zoë's editing permissions match your own. The data model is governed by the same role-based rules whether you edit by hand in Context Manager or ask Zoë to do it from chat:
 
-* If you are an **Explore** or **View** user (or any role without `data_model_edit`), Zoë cannot edit the data model. She will draft recommendations and explain that you or a workspace admin needs to apply them.
+* If you are an **Explore**, **View**, or **Restricted** user (or any role without `data_model_edit`), Zoë cannot edit the data model. She will draft recommendations and explain that you or a workspace admin needs to apply them.
 * If you are **Develop**, **Develop without Deploy**, or **Admin**, Zoë can edit the data model on the branch you are currently on, as long as that branch is not the production branch.
 * Only workspace **Admins** and users with the **Develop** role (which carries `deploy_to_production`) can deploy a development branch to the production branch. Deployment happens in [Context Manager](../zenlytic-ui/context_manager.md), not from chat.
 

--- a/data-modeling/asking-zoe-for-recommendations.md
+++ b/data-modeling/asking-zoe-for-recommendations.md
@@ -94,7 +94,7 @@ When edits are turned on, Zoë's editing permissions match your own. The data mo
 
 ### Editing the production branch directly
 
-Asking Zoë to save a change on the production branch is gated by the same workspace setting that gates manual production edits in Context Manager: the **Allow Edit Production** toggle at **Workspace Settings → Git → Allow Edit Production** (on by default). Zoë will save on the production branch only if you are an **Admin** or **Develop** user and the toggle is on. Otherwise she'll refuse the edit and ask you to switch to a development branch. See [Work with branches safely](../zenlytic-ui/context_manager.md#work-with-branches-safely) for more on the toggle.
+You can allow Zoë to save edits on the production branch by turning on the **Allow Edit Production** toggle at **Workspace Settings → Git → Allow Edit Production**. With the toggle on, Zoë will save changes on the production branch for **Admin** and **Develop** users. With it off, she'll refuse production edits and ask you to switch to a development branch. The toggle is on by default and uses the same setting that controls manual production edits in Context Manager. See [Work with branches safely](../zenlytic-ui/context_manager.md#work-with-branches-safely) for more on the toggle.
 
 See [User Roles](../zenlytic-ui/user_roles.md) for the full role and permission reference.
 

--- a/data-modeling/asking-zoe-for-recommendations.md
+++ b/data-modeling/asking-zoe-for-recommendations.md
@@ -113,7 +113,7 @@ Zoë's edits and recommendations aren't always perfect on the first try. If a ch
 ## Related
 
 * [Context Manager](../zenlytic-ui/context_manager.md): where you apply Zoë's recommendations or review her commits
-* [Context Surfaces](../core-concepts/context-surfaces.md): when to use `description`, `zoe_description`, synonyms, or the system prompt; also covers the enable/disable toggle and the surfaces Zoë can edit
+* [Context Surfaces](../core-concepts/context-surfaces.md): when to use `description`, `zoe_description`, synonyms, or the system prompt
 * [User Roles](../zenlytic-ui/user_roles.md): the role and permission reference Zoë inherits from
 * [Fixing Zoë's Mistakes](../core-concepts/fixing-zoes-mistakes.md) — diagnostic flow when Zoë gives a wrong answer
 * [Measures](measure.md) — valid/invalid aggregation patterns for measure SQL


### PR DESCRIPTION
## Summary

Documents the new Zoë Context Editing feature, which lets Zoë create, edit, and commit data model YAML, the workspace `system_prompt.md`, and workspace `skills/` directly from chat (controlled by the `zoe-context-editor` flag and the workspace `allow_zoe_context_editing` setting).

- **`core-concepts/context-surfaces.md`** — adds a "Letting Zoë edit context for you" section covering the surfaces Zoë can edit, her validate-then-commit workflow, branch/permission rules, and the **Workspace Settings → Chat Settings → Context Editing** toggle. Placed here (the canonical page) rather than in `tips-and-tricks/zoe_context_ingestion.md`, which is now a redirect stub pointing here.
- **`data-modeling/asking-zoe-for-recommendations.md`** — reframes the page around recommend vs. apply modes:
  - Removes the now-incorrect line "Zoë's recommendations are suggestions, not automatic changes — she doesn't edit your data model files directly."
  - Adds a full apply-mode workflow (read → draft → validate → save → sample-query → report).
  - Adds an "Enabling or disabling Zoë's edits" section with the toggle path and the permission/branch matrix.
  - Adds a "What Zoë won't do" section.
  - Preserves the existing measure and relationship examples.

## Test plan

- [ ] Verify both pages render correctly in the GitBook preview
- [ ] Confirm internal cross-links resolve (Context Manager, Skills, Measures, Relationships, Fixing Zoë's Mistakes, Progressive Enrichment, Memories, Migrating from Memories and Topics)
- [ ] Sanity-check tone and product naming with @nick / docs reviewers
- [ ] Optional follow-up: add a screenshot of the **Chat Settings → Context Editing** toggle and a sample chat showing apply mode in action

Made with [Cursor](https://cursor.com)