### PR TITLE
Reframe onboarding around iterative Zoë-led enrichment (Fin AI fix)

### DIFF
--- a/data-modeling/asking-zoe-for-recommendations.md
+++ b/data-modeling/asking-zoe-for-recommendations.md
@@ -1,5 +1,9 @@
 # Ask Zoë for Data Model Recommendations
 
+{% hint style="success" %}
+**There is no separate "training" step for Zoë.** The way to make Zoë good at your data — including new and complex datasets — is to ask her in chat. She'll recommend context to add (descriptions, synonyms, measures, joins, skills, system prompt rules), explain where each change belongs, and with edits enabled save them to your repo. The rest of this page covers how that workflow works in practice.
+{% endhint %}
+
 You don't have to author your data model alone. Zoë can recommend changes directly from chat: new measures, new dimensions, new relationships, calculation logic, view and field documentation, workspace skills, updates to the system prompt, or restructuring something that isn't answering questions well. [If you've allowed her to](#turning-context-editing-on-or-off), she can also make those changes for you and save them to your repository on the current branch.
 
 Ask in plain English. Either let Zoë draft a snippet for you to paste in [Context Manager](../zenlytic-ui/context_manager.md), or tell her to make the change for you.
@@ -13,6 +17,8 @@ Good questions to bring to Zoë:
 * **"How should these tables be joined?"** — e.g. "What's the right relationship between `orders` and `shipments`?"
 * **"Why did you pick the wrong field?"** — Zoë can often diagnose why she chose the wrong field and recommend adding a `synonym`, `zoe_description`, or a new measure to prevent it next time. See also [Fixing Zoë's Mistakes](../core-concepts/fixing-zoes-mistakes.md).
 * **"What should I add to this view to make it more useful?"** — Zoë can look at a view and recommend missing measures, synonyms, or descriptions.
+* **"Which tables should I import for [use case]?"** — Zoë can read your warehouse's `information_schema` and suggest a starting set of tables based on the analysis you want to do, including tables you haven't imported yet.
+* **"What data would I need to recreate this report?"** — paste a screenshot of an existing dashboard or report (Power BI, Tableau, Looker, etc.) and Zoë will identify the tables and fields you'd need. Because she can see your full warehouse schema, she can recommend new tables to bring in.
 
 ## Letting Zoë make the change for you
 
@@ -36,6 +42,18 @@ The surfaces Zoë can edit:
 She follows the same authoring rules a human editor would: flat `fields:` lists, valid measure patterns, conservative use of `searchable: true`, and `zoe_description` rather than `description` for agent-only guidance. See [Context Surfaces](../core-concepts/context-surfaces.md) for the full decision tree.
 
 If you'd rather have Zoë just review without editing, ask her to "audit the model", "recommend changes", or "check whether she has enough context". She'll inspect the data model and report findings without saving anything, and only commits when you explicitly ask her to make the change.
+
+## For complex datasets
+
+Don't try to model everything before testing. The fastest way to get a complex or unfamiliar dataset working with Zoë is to build context iteratively:
+
+1. **Import the tables.** Ask Zoë which ones to start with if you're not sure. Set `default_date` on time-series views — that one property is the biggest single win for temporal questions.
+2. **Ask a real business question.** Not "explain everything" — something you actually want answered.
+3. **When Zoë gets something wrong, ask her why.** "Why did you pick that field?" or "What context would help you answer this correctly?" She'll diagnose the specific cause and recommend the smallest fix.
+4. **For domain-specific or multi-step logic** (fiscal calendar, custom segmentations, complex joins, industry-specific patterns), have Zoë create a [Skill](../zenlytic-ui/skills.md) instead of stuffing it into individual descriptions.
+5. **Repeat.** Each round narrows the gap between your data and Zoë's accuracy.
+
+This works far better than building a full semantic model upfront. The complexity ends up encoded exactly where it's needed, not speculatively everywhere.
 
 ## Example: adding a measure
 

--- a/getting-started/start_here.md
+++ b/getting-started/start_here.md
@@ -1,13 +1,13 @@
 # Start Here
 
-Welcome to Zenlytic. This page walks you from a blank workspace to asking Zoë your first real question. The shortest version:
+Welcome to Zenlytic. The shortest path from a blank workspace to a working AI analyst:
 
-1. **Connect your data warehouse.**
-2. **Import a few raw tables.**
-3. **Ask Zoë a question.**
-4. **When something's wrong, add the smallest piece of context that fixes it — then ask again.**
+1. **Connect** your data warehouse.
+2. **Import a few tables** — or ask Zoë which ones to start with.
+3. **Ask Zoë a real question** — and check her work.
+4. **Ask Zoë how to make herself better** — and let her recommend (or apply) the changes.
 
-You don't need a fully built-out data model before you start getting value. The fastest path to a good experience is to import the tables you care about, ask real questions, and let the mistakes tell you what to configure next.
+The whole onboarding is a conversation. You don't need to build a finished data model before getting value, and you don't have to author context from scratch — Zoë can recommend, and with permission save, most of the changes you'd otherwise write by hand.
 
 ## Step 1 — Connect your data warehouse
 
@@ -19,27 +19,61 @@ For a reference, see the [demo data model](https://github.com/Zenlytic/demo-data
 
 ![Finish Connection](../.gitbook/assets/finish-connection.png)
 
-## Step 2 — Git for your data model
+## Step 2 — Import tables (or ask Zoë to)
 
-Git is already connected by default. Keep using Zenlytic's **Managed Repo** unless you have a reason to switch — it requires zero setup. If you later need to switch to your own repo, contact support.
+The traditional path: open [Context Manager](../zenlytic-ui/context_manager.md), click **Add → Add view → Add from a database connection**, and pick the tables you want.
 
-## Step 3 — Import raw tables and ask a question
+The faster path: **just ask Zoë.** Once your warehouse is connected, Zoë can read your `information_schema` — she sees every table available through that connection, not just the ones already imported. Try:
 
-Open [Context Manager](../zenlytic-ui/context_manager.md) from the workspace navigation or from chat. Add a view from the **Context** tab — you can either upload a CSV or pick tables from your database connection. Zenlytic reads the `information_schema` to pull in metadata and, on warehouses like Snowflake, BigQuery, and Databricks, imports column and table descriptions too.
+* "Which tables should I import to answer questions about retention?"
+* "Add the orders, customers, and shipments tables to my model."
+* "What's a good first set of tables to start with for revenue analysis?"
 
-Once the tables are imported:
+### Migrating from another BI tool
 
-* Each imported table becomes a [view](../data-modeling/view.md) with dimensions auto-generated from the columns.
-* Pick a sensible `default_date` for each view that has time-series data. This one property has an outsized effect on temporal questions.
-* **That's enough to start.** Go ask Zoë a question.
+If you're moving from Power BI, Tableau, Looker, or another reporting platform, you don't have to figure out the mapping yourself. **Paste a screenshot of an existing report into chat and ask Zoë what data she'd need to recreate it.** She'll match the report's metrics and dimensions to your warehouse tables, tell you what to import, and — with edits enabled — do the import.
 
-You don't need to define every metric, write every description, or set up relationships before testing. Raw tables with decent names will get you surprisingly far. The full walkthrough for the editor, branch workflows, diffs, and deployment lives on the [Context Manager](../zenlytic-ui/context_manager.md) page.
+You can also describe the question without a screenshot — *"what data would I need to track new vs. repeat customer revenue by channel?"* — and Zoë will identify the relevant tables and fields the same way.
 
-## Step 4 — Iterate based on what goes wrong
+See [Ask Zoë for Data Model Recommendations](../data-modeling/asking-zoe-for-recommendations.md) for the full workflow.
 
-When Zoë answers something incorrectly — picks the wrong field, constructs a wrong join, uses the wrong aggregation — **don't guess at a fix**. Classify the error first, then add the smallest piece of context that would have prevented it.
+### Once tables are imported
 
-The full diagnostic router lives at [Fixing Zoë's Mistakes](../core-concepts/fixing-zoes-mistakes.md). In short:
+Each imported table becomes a [view](../data-modeling/view.md) with dimensions auto-generated from the columns. **Set `default_date` on any time-series views** — that one property has an outsized effect on temporal questions and is the highest-leverage thing you can do early.
+
+You don't need to define every metric or write every description before testing. Raw tables with decent names will get you surprisingly far. The full walkthrough for the editor, branch workflows, diffs, and deployment lives on the [Context Manager](../zenlytic-ui/context_manager.md) page.
+
+## Step 3 — Ask Zoë a real question (and check her work)
+
+Open Zoë and ask something you actually want answered:
+
+* "What was revenue last quarter compared to the quarter before?"
+* "Which products had the biggest YoY drop in margin?"
+* "Show me sessions by channel for the last 30 days."
+
+When she responds, **check her work**. Every chart and table has citations showing which fields and joins backed the answer. Click into them. Does the SQL match what you expected? Is she using the right field? Joining the right tables?
+
+If something looks off, that's the signal for Step 4.
+
+## Step 4 — Ask Zoë how to improve
+
+When Zoë gets something wrong — and she will, at first — **don't guess at a fix**. Ask her:
+
+* "Why did you pick that field?"
+* "What context would help you answer this correctly next time?"
+* "How should I model the join between orders and shipments?"
+* "Add a measure for repeat purchase rate."
+* "Create a skill for our fiscal calendar."
+
+She'll diagnose the specific cause and recommend the smallest change that prevents the same mistake — a better `zoe_description`, a synonym, a missing measure, a new relationship, a system-prompt rule, or a skill for complex domain logic. With edits enabled, she can apply the change directly to your repo on the current branch.
+
+This is the loop:
+
+> Ask → check → ask Zoë what would help → save the fix → ask again.
+
+Over time your model ends up configured exactly where it matters, not in places that turned out not to. **There is no separate "training" step for Zoë.** Your data model grows in response to real questions.
+
+For shortcuts:
 
 * **Wrong field picked?** Add `synonyms` for the term your users said.
 * **Right field, used wrong?** Add a `zoe_description` clarifying when to use it vs. alternatives.
@@ -47,15 +81,17 @@ The full diagnostic router lives at [Fixing Zoë's Mistakes](../core-concepts/fi
 * **Wrong date or date range?** Check `default_date`; use `canon_date` sparingly on individual measures.
 * **Invalid measure?** Check the valid/invalid patterns on the [Measures](../data-modeling/measure.md) page.
 
-After you make the change, re-ask the original question to verify. Over time, your model ends up configured in exactly the places where it matters, not in places that turned out not to.
-
-See [Progressive Enrichment](../core-concepts/progressive-enrichment.md) for the priority order of what to reach for, and [Context Surfaces](../core-concepts/context-surfaces.md) for where each kind of context lives.
+See [Progressive Enrichment](../core-concepts/progressive-enrichment.md) for the priority order of what to reach for, [Context Surfaces](../core-concepts/context-surfaces.md) for where each kind of context lives, and [Fixing Zoë's Mistakes](../core-concepts/fixing-zoes-mistakes.md) for the full diagnostic flow.
 
 ## Step 5 — Ship it
 
 When your changes are on a development branch and you're ready to make them live, use the **Deploy to production** action in [Context Manager](../zenlytic-ui/context_manager.md). That publishes the branch so Zoë (and the rest of your org) is using the latest version. Resolve any validation errors first.
 
 If changes were pushed to git directly rather than through the UI, use the [force-refresh](../data-modeling/cache-refresh.md) button to rebuild the cache.
+
+## Git for your data model
+
+Git is connected by default. Keep using Zenlytic's **Managed Repo** unless you have a reason to switch — it requires zero setup. If you later need to switch to your own repo, contact support.
 
 ## FAQ
 
@@ -76,9 +112,10 @@ If changes were pushed to git directly rather than through the UI, use the [forc
 
 ## Where do I go from here?
 
-* Learn the UI — [Using Zenlytic](../zenlytic-ui/using_zenlytic.md)
-* Learn the data model — [Data Modeling Overview](../data-modeling/data_modeling.md)
-* Start steering Zoë — [Context Surfaces](../core-concepts/context-surfaces.md)
-* Fix specific errors — [Fixing Zoë's Mistakes](../core-concepts/fixing-zoes-mistakes.md)
+* **[Ask Zoë for Data Model Recommendations](../data-modeling/asking-zoe-for-recommendations.md)** — the most important page if you want Zoë to help you build context
+* [Context Surfaces](../core-concepts/context-surfaces.md) — where each kind of context lives
+* [Fixing Zoë's Mistakes](../core-concepts/fixing-zoes-mistakes.md) — diagnostic flow when answers are off
+* [Using Zenlytic](../zenlytic-ui/using_zenlytic.md) — the rest of the UI
+* [Data Modeling Overview](../data-modeling/data_modeling.md) — for hands-on data model authoring
 
 As always, feel free to reach out to your Zenlytic contact or [email support](mailto:support@zenlytic.com) if anything here doesn't match what you're seeing.

--- a/zenlytic-ui/memories.md
+++ b/zenlytic-ui/memories.md
@@ -1,8 +1,16 @@
-{% hint style="warning" %}
-**Memories are legacy and are being replaced by [Skills](skills.md).** You can still create and use memories today, and existing memories will be migrated automatically in a future release. For new context, use [Skills](skills.md) — they cover the same ground with fewer limitations. New joins, field-level context, and universal rules should go on the data model or in the system prompt rather than in a memory. See [Migrating from Memories and Topics](../migrations/migrating-from-memories-and-topics.md) for a side-by-side comparison.
+{% hint style="danger" %}
+**Memories are legacy. Do not use them for new context.** Memories are being retired and replaced by [Skills](skills.md). Existing memories will continue to work and will be migrated automatically in a future release, but **for any new context you want to add, do not create a memory**. Use one of these instead:
+
+* **Recurring patterns or domain logic** → create a [Skill](skills.md).
+* **Universal rules and terminology** → add to the system prompt.
+* **Field- or table-specific guidance** → put it on the view or field as a `zoe_description`. See [Context Surfaces](../core-concepts/context-surfaces.md) for the decision tree.
+
+The rest of this page documents the legacy Memories feature for users who already have memories in their workspace. See [Migrating from Memories and Topics](../migrations/migrating-from-memories-and-topics.md) for a side-by-side comparison.
 {% endhint %}
 
-# Memories
+# Memories (legacy)
+
+> Legacy feature. For new context, use [Skills](skills.md), the system prompt, or `zoe_description` on views and fields.
 
 Use memories to teach Zoë about your company, your data preferences, and how you want questions answered. Zoë uses these memories to understand your business and remember your preferences in future responses.
 


### PR DESCRIPTION
## Why

Triggered by an Intercom conversation where Fin gave a customer with a complex dataset onboarding-style boilerplate and recommended **Memories** — a deprecated feature. The customer (Darwin at At Home) wanted to know how to *teach Zoë* about a complex dataset; Fin over-cited Start Here and a legacy Memories help-center article.

Two root causes:

1. **Start Here** is being treated by Fin as the catch-all answer for "how do I make Zoë good at my data" — but it's written for first-time setup, not for the iterative-enrichment loop that solves the actual question.
2. **Memories** still ranks as a recommendable workflow despite being legacy, because the deprecation banner was the soft \`warning\` style and the page title didn't carry the "(legacy)" tag.

## Changes

### `getting-started/start_here.md` — full rewrite

Reframes the page as a four-step conversational loop, with the iterative philosophy as the page thesis (not buried in Step 4):

1. **Connect** your warehouse
2. **Import tables** — or ask Zoë which ones to start with
3. **Ask Zoë a real question** — and check her work
4. **Ask Zoë how to make herself better** — and let her recommend or apply the changes

New material:

- Step 2 documents that Zoë reads the `information_schema` and can recommend tables to import.
- New **"Migrating from another BI tool"** subsection: paste a screenshot of an existing Power BI / Tableau / Looker report and Zoë identifies the tables and fields you'd need.
- Step 4 explicitly says *"There is no separate 'training' step for Zoë"* — addresses the customer's mental model head-on.
- "Where do I go from here?" now leads with **Ask Zoë for Data Model Recommendations** as the most important next page.

Preserved: Step 1 prose + finish-connection screenshot, FAQ, Step 5 (Ship it), Git/Managed-Repo note (moved to its own section at the bottom).

### `data-modeling/asking-zoe-for-recommendations.md` — promoted as the canonical destination

- **New \`style=\"success\"\` TLDR callout at the top** explicitly addressing the \"training\" mental model so Fin's ranker picks this page up for that question family.
- **Two new bullets** under \"When to ask Zoë instead of authoring from scratch\":
  - \"Which tables should I import for [use case]?\" → schema visibility
  - \"What data would I need to recreate this report?\" → screenshot-a-report migration workflow
- **New \"For complex datasets\" section** covering the iterative recipe (import → ask → diagnose → skill for domain logic → repeat).

### `zenlytic-ui/memories.md` — harden the deprecation

- Banner upgraded from \`style=\"warning\"\` to \`style=\"danger\"\` with explicit \"Do not use them for new context\" language.
- Banner now includes a routing table: Skills / system prompt / `zoe_description` with links to Context Surfaces.
- H1 retitled to **\"Memories (legacy)\"** so Fin's content index sees the deprecation in the page title itself, not just in the banner body.
- Single-line \"Legacy feature\" reminder added right after the H1 in case Fin's ranker only reads the first paragraph.
- All existing Memories prose preserved for customers who already have memories in their workspace.

## Fin AI follow-ups (out of repo scope)

Two related cleanups need to happen in Intercom directly (not in this PR):

1. Update or archive the legacy Intercom Help Center article [\"How to Use Memories in Zenlytic\"](https://support.zenlytic.com/en/articles/12739443) — Fin is citing it as a recommendation source.
2. Update or archive [\"Connecting Tables - Joins and Identifiers\"](https://support.zenlytic.com/en/articles/11662913) — Joins and Identifiers are legacy in favor of Relationships.

Worth checking Fin's content source list after this merges to confirm the docs page changes are picked up and the legacy articles are no longer being recommended for new-context questions.

## Stats

- 3 files changed
- 91 insertions, 28 deletions
- No new images; no SUMMARY changes; no broken links introduced.

## Test plan

- [ ] GitBook preview renders all three pages cleanly
- [ ] No prose references to a separate \"training\" step remain on Start Here (verified by grep)
- [ ] Memories page H1 reads \"Memories (legacy)\" in the rendered preview
- [ ] All cross-links from Start Here to Ask Zoë / Context Surfaces / Fixing Zoë's Mistakes resolve
- [ ] @pblankley confirms the iterative loop framing in Step 4 matches the intended philosophy
- [ ] After merge: re-ask the original Darwin question in Fin and confirm it no longer recommends Memories

🤖 Generated with [Claude Code](https://claude.com/claude-code)