### PR TITLE
Document skill front matter properties (name, description, enabled)

### DIFF
--- a/migrations/migrating-from-memories-and-topics.md
+++ b/migrations/migrating-from-memories-and-topics.md
@@ -37,6 +37,8 @@ Created in the **Context Manager**:
 
 Skills are broader than memories by design. A single skill can cover an entire topic area, an industry-specific calendar, or a multi-step workflow, with no hard character limit. See [Skills](../zenlytic-ui/skills.md).
 
+Migrated skills include metadata like a skill ID, migration ID, and migration timestamp in their front matter. You can safely remove these, but we recommend leaving them in as a record of when the content was migrated. Only `name` and `description` are required; see [Skill properties](../zenlytic-ui/skills.md#skill-properties).
+
 ### When to move a memory today
 
 You do not need to move existing memories — they will be migrated automatically. But if you are actively adding new context, create a skill instead:

--- a/zenlytic-ui/skills.md
+++ b/zenlytic-ui/skills.md
@@ -71,6 +71,24 @@ To create a new skill:
 
 <figure><img src="../.gitbook/assets/skills-create-new.png" alt=""><figcaption></figcaption></figure>
 
+## Skill properties
+
+Each skill is a markdown file with YAML front matter at the top:
+
+```yaml
+---
+name: Weekly Report Format
+description: How to structure and format the weekly business review.
+enabled: true
+---
+```
+
+* **`name`** (required) — the skill's display name.
+* **`description`** (required) — a short summary of what the skill does. Zoë uses the description to decide when to load the skill, so be specific about when it should apply.
+* **`enabled`** (optional) — controls whether Zoë can see the skill. Set `enabled: false` to hide the skill from Zoë. If `enabled: true` is set, or the property is omitted, Zoë sees the skill.
+
+Skills migrated from memories may also include metadata like a skill ID, migration ID, and migration timestamp. You can safely remove these, but we recommend leaving them in place as a record of when the content was migrated.
+
 ## Who can create skills?
 
 Skill management is gated by role. Only **Developer** and **Admin** tier users (Develop, Develop without Deploy, Admin, and Organization Admin) can create, edit, or delete skills, since skills affect context for the entire organization. Users in the **Explorer** tier (Explore, View, Restricted, Embed, Embed with SQL, Embedded with Scheduling) cannot manage skills, but they can still use skills that Developer and Admin users have set up.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Documents the YAML front matter properties on skill files, based on the office hours follow-up about the `enabled` flag:

- Adds a **Skill properties** section to `zenlytic-ui/skills.md` covering:
  - `name` (required) — the skill's display name.
  - `description` (required) — used by Zoë to decide when to load the skill.
  - `enabled` (optional) — `enabled: false` hides the skill from Zoë; `enabled: true` or omitting the property makes it visible.
  - A note that migrated skills may carry a skill ID, migration ID, and migration timestamp, which can be safely removed but are worth keeping as a migration record.
- Adds a short note in `migrations/migrating-from-memories-and-topics.md` about migrated-skill metadata, linking to the new Skill properties section.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bdd1d3d6-f8a2-4528-86aa-af78b38cad73"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bdd1d3d6-f8a2-4528-86aa-af78b38cad73"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

