### PR TITLE
Fix stale explore_from_here permission description

### DIFF
--- a/zenlytic-ui/user_roles.md
+++ b/zenlytic-ui/user_roles.md
@@ -32,7 +32,7 @@ Each of the role bundles below is built from the following individual permission
 
 `view_content`: This is the ability to view dashboards.
 
-`explore_from_here`: This is the ability to "Explore from here" to the graphical UI to change a query found on a dashboard or in Zoë.
+`explore_from_here`: This is the ability to continue analysis from an existing result or dashboard.
 
 `edit_settings`: This is the admin permission to edit the settings of the workspace itself. With this permission, a user can grant him/herself any permission.
 


### PR DESCRIPTION
## Why

Found while auditing Intercom Help Center articles for consistency after the Explore UI deprecation (#118). The `explore_from_here` permission in `user_roles.md` was still described as *"the ability to 'Explore from here' to the graphical UI to change a query found on a dashboard or in Zoë"* — a reference to the standalone Explore UI that no longer exists. Confirmed with Greg: only the Explore **role** remains; the Explore UI (including any \"Explore from here\" graphical drill-in) is gone.

This slipped through PR #111's CTO review since the permission's plumbing (name, matrix membership) was correct — only the prose description was stale.

## What changed

One line in `zenlytic-ui/user_roles.md`:

> `explore_from_here`: This is the ability to \"Explore from here\" to the graphical UI to change a query found on a dashboard or in Zoë.

→

> `explore_from_here`: This is the ability to continue analysis from an existing result or dashboard.

Matches the corresponding fix just made to the Intercom Help Center twin of this content ([\"User roles and permissions in Zenlytic\"](https://support.zenlytic.com/en/articles/9264249)).

## Test plan

- [ ] GitBook preview renders the updated line
- [ ] Confirm no other page references \"Explore from here\" as a current UI surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)