### PR TITLE
Document commit identity and repo rules for GitHub deploy key setup

### DIFF
--- a/authentication-and-security/connecting_to_github_with_a_deploy_key.md
+++ b/authentication-and-security/connecting_to_github_with_a_deploy_key.md
@@ -6,6 +6,31 @@ description: >-
 
 # Connecting To Github With A Deploy Key
 
+## Commit identity and repository rules
+
+Zenlytic writes to your repo every time a user saves model files from Context Manager. Every commit Zenlytic creates uses a fixed identity:
+
+* **Author:** the email of the Zenlytic user who made the change
+* **Committer:** `Zenlytic <hello@zenlytic.com>` on every commit, regardless of who made the change
+* **Signature:** none — Zenlytic does not sign its commits
+
+{% hint style="warning" %}
+If your organization enforces rules on commit metadata, allow `hello@zenlytic.com` **before** you connect. Otherwise branch creation will succeed but every save will fail — these rules apply to every branch, not only protected ones. That's why creating a branch from Context Manager can succeed (no commit is created yet) while the first save fails (a commit is created).
+{% endhint %}
+
+Check these settings in GitHub, at both the organization and repository level (a clean repo-level ruleset doesn't rule out an organization-level one):
+
+| Setting | Where to find it | What to do |
+|---|---|---|
+| Restrict commit metadata (committer email) | Rulesets | Allow `hello@zenlytic.com` |
+| Require signed commits | Rulesets, or classic branch protection | Disable for this repo |
+
+The push itself still authenticates with the deploy key you install below — your access control is unchanged. Only the commit metadata carries the Zenlytic service identity.
+
+**Symptom if this isn't configured:** "Save Model Files Unsuccessful / Failed to save model" in Context Manager on every branch. The underlying push is rejected with a rule violation naming the committer email `hello@zenlytic.com`.
+
+## Connecting your repository
+
 **Step 1:** In Zenlytic, you'll first go into Settings, then Workspace Settings
 
 ![Github Deploy Key 1](../.gitbook/assets/github-deploy-key-1.png)

--- a/authentication-and-security/connecting_to_github_with_a_deploy_key.md
+++ b/authentication-and-security/connecting_to_github_with_a_deploy_key.md
@@ -25,6 +25,8 @@ Check these settings in GitHub, at both the organization and repository level (a
 | Restrict commit metadata (committer email) | Rulesets | Allow `hello@zenlytic.com` |
 | Require signed commits | Rulesets, or classic branch protection | Disable for this repo |
 
+Metadata restrictions (including committer email pattern) require **GitHub Enterprise Cloud or Enterprise Server** — this option won't appear under Rulesets on GitHub Free, Pro, or Team.
+
 The push itself still authenticates with the deploy key you install below — your access control is unchanged. Only the commit metadata carries the Zenlytic service identity.
 
 **Symptom if this isn't configured:** "Save Model Files Unsuccessful / Failed to save model" in Context Manager on every branch. The underlying push is rejected with a rule violation naming the committer email `hello@zenlytic.com`.


### PR DESCRIPTION
## Why

A customer's git host was silently rejecting every Zenlytic save (but not branch creation) because their ruleset restricted commit committer email, and Zenlytic commits every save as `hello@zenlytic.com`. Root-caused by Paul from the support case. Nothing in the current nine-step deploy-key guide mentions commit identity, so an admin has no way to know they need to allow this before connecting.

## What changed

Added a new **Commit identity and repository rules** section at the top of [connecting_to_github_with_a_deploy_key.md](authentication-and-security/connecting_to_github_with_a_deploy_key.md), before the connection steps:

- Zenlytic's fixed commit identity (author = the acting user, committer always `hello@zenlytic.com`, unsigned)
- A warning callout: allow the committer email *before* connecting, since these rules apply to every branch — this is why branch creation can succeed while every save then fails
- Which GitHub settings to check (Rulesets — org level and repo level — and signed-commit requirements)
- The exact failure symptom ("Save Model Files Unsuccessful") so this is findable/searchable when a customer hits it

Wrapped the existing nine steps under their own **Connecting your repository** heading to keep the new section clearly separate.

## Test plan

- [ ] Render locally / preview in GitBook to confirm the new `{% hint style="warning" %}` block and table render correctly
- [ ] Spot-check the page on docs.zenlytic.com after merge