### PR TITLE
Fix four stale internal links from the Docusaurus migration

### DIFF
--- a/docs/authentication-and-security/microsoft_entra_zenlytic.md
+++ b/docs/authentication-and-security/microsoft_entra_zenlytic.md
@@ -121,7 +121,7 @@ Must be one of these values:\
 ​`zenlytic_user_attributes`
 
 Allows you to manually control access to data.\
-Read about how user attributes work here in [Zenlytic Docs](../3_zenlytic_ui/user_attributes/).\
+Read about how user attributes work here in [User Attributes](../zenlytic-ui/user_attributes.md).\
 Should follow this format. An array of key/value pairs.\
 \- Ex: `[{\"department\": \"Engineering\"}]`
 

--- a/docs/data-sources/druid_setup.md
+++ b/docs/data-sources/druid_setup.md
@@ -12,7 +12,7 @@ This document will help you connect your Apache Druid data warehouse to Zenlytic
 
 ## Connection Name
 
-First, you'll name your connection. This name is how Zenlytic's [model](../5_data_modeling/model/) connects the credentials you'll enter in the next step to your data warehouse. You can name the credential whatever you want, but we usually recommend naming it something like `my_company_name` to keep things simple.
+First, you'll name your connection. This name is how Zenlytic's [model](../data-modeling/model.md) connects the credentials you'll enter in the next step to your data warehouse. You can name the credential whatever you want, but we usually recommend naming it something like `my_company_name` to keep things simple.
 
 ## Host
 

--- a/docs/data-sources/snowflake_setup.md
+++ b/docs/data-sources/snowflake_setup.md
@@ -12,7 +12,7 @@ This document will help you connect your Snowflake data warehouse to Zenlytic to
 
 ## Connection Name
 
-First, you'll name your connection. This name is how Zenlytic's [model](../5_data_modeling/model/) connects the credentials you'll enter in the next step to your data warehouse. You can name the credential whatever you want, but we usually recommend naming it something like `my_company_name` to keep things simple.
+First, you'll name your connection. This name is how Zenlytic's [model](../data-modeling/model.md) connects the credentials you'll enter in the next step to your data warehouse. You can name the credential whatever you want, but we usually recommend naming it something like `my_company_name` to keep things simple.
 
 ## Account
 

--- a/docs/data-sources/trino_onboarding.md
+++ b/docs/data-sources/trino_onboarding.md
@@ -12,7 +12,7 @@ This document will help you connect your Trino data warehouse to Zenlytic to acc
 
 ## Connection Name
 
-First, you'll name your connection. This name is how Zenlytic's [model](../5_data_modeling/model/) connects the credentials you'll enter in the next step to your data warehouse. You can name the credential whatever you want, but we usually recommend naming it something like `my_company_name` to keep things simple.
+First, you'll name your connection. This name is how Zenlytic's [model](../data-modeling/model.md) connects the credentials you'll enter in the next step to your data warehouse. You can name the credential whatever you want, but we usually recommend naming it something like `my_company_name` to keep things simple.
 
 ## Host
 


### PR DESCRIPTION
Four in-page links still pointed at old numbered paths. They produced **no build error and looked completely normal on the page**, which is why they survived the migration.

## What was actually happening

GitBook doesn't fail on a link it can't resolve — it silently rewrites it into a **GitHub source URL**. So the reader saw an ordinary link, clicked it, left docs.zenlytic.com, and hit a GitHub 404:

```
"Zenlytic Docs" → github.com/Zenlytic/zenlytic-docs/tree/main/docs/3_zenlytic_ui/user_attributes/README.md   404
"model"         → github.com/Zenlytic/zenlytic-docs/tree/main/docs/5_data_modeling/model/README.md           404
```

## The fix

| File | Was | Now |
|---|---|---|
| `authentication-and-security/microsoft_entra_zenlytic.md` | `../3_zenlytic_ui/user_attributes/` | `../zenlytic-ui/user_attributes.md` |
| `data-sources/snowflake_setup.md` | `../5_data_modeling/model/` | `../data-modeling/model.md` |
| `data-sources/trino_onboarding.md` | `../5_data_modeling/model/` | `../data-modeling/model.md` |
| `data-sources/druid_setup.md` | `../5_data_modeling/model/` | `../data-modeling/model.md` |

Also retitles the Entra link from "Zenlytic Docs" to **"User Attributes"** — it points at a specific page, and "Zenlytic Docs" as link text on the Zenlytic docs site says nothing.

## Why this was missed before

My earlier link check in #129 reported "501 links, 0 broken." That was wrong twice over:

1. It only matched links ending in `.md`. All four of these are **directory-style** (`.../model/`) with no suffix.
2. It tested file existence on disk, which can't detect the GitHub-rewrite behavior at all.

The only reliable test is fetching the rendered page and inspecting the emitted `href`:

```bash
curl -sL <page-url> | grep -o 'href="https://github.com/Zenlytic/zenlytic-docs[^"]*"'
```

Any hit is a broken in-page link. Added to `CLAUDE.md` alongside the related redirect gotcha.

## Verification

- **512 internal links** across `docs/`, `changelog/`, `developer/`, `resources/` — now matching every link form, not just `.md`. **Zero broken.**
- No remaining Docusaurus numbered paths anywhere, except `docs/2_data_modeling/topic` in `.gitbook.yaml`, which is a redirect **source** key (an old URL being redirected *from*) and correct as-is.

Post-merge I'll re-fetch the four pages and confirm the hrefs resolve on-site rather than escaping to GitHub.