### PR TITLE
Fix duplicated steps and stale copy on the Microsoft Entra pages

### DIFF
--- a/docs/authentication-and-security/microsoft_entra_snowflake/README.md
+++ b/docs/authentication-and-security/microsoft_entra_snowflake/README.md
@@ -19,7 +19,7 @@ This document will guide you through the process of enabling Microsoft Entra (fo
 
 ## Understanding the Requirements
 
-Zenlytic will need both access to both of the flows listed in Snowflake's guide:
+Zenlytic needs access to both of the flows listed in Snowflake's guide:
 
 1. The authorization server can grant the OAuth client an access token on behalf of the user.
 2. The authorization server can grant the OAuth client an access token for the OAuth client itself.
@@ -42,11 +42,11 @@ Zenlytic will need both access to both of the flows listed in Snowflake's guide:
 1. Click on **Expose an API**.
 2. Click on the **Add** link next to **Application ID URI** to set the `Application ID URI`.
 
-> **Important**
->
-> The Application ID URI must be unique within your organization's directory, such as https://your.company.com/4d2a8c2b-a5f4-4b86-93ca-294185f45f2e.
->
-> **Tip**: You can use a unique id generator website like [UUID Generator](https://www.uuidgenerator.net/) for the second part of the url
+   > **Important**
+   >
+   > The Application ID URI must be unique within your organization's directory, such as `https://your.company.com/4d2a8c2b-a5f4-4b86-93ca-294185f45f2e`.
+   >
+   > **Tip:** You can use a unique ID generator such as [UUID Generator](https://www.uuidgenerator.net/) for the second part of the URL.
 
 3. Now we'll add the scope for the web app client, click on **Add a scope** to add a scope representing the Snowflake role.
    * Enter the scope by having the name of the Snowflake role with the `session:scope:` prefix. For example, for the Snowflake Analyst role, enter `session:scope:analyst`.
@@ -57,8 +57,7 @@ Zenlytic will need both access to both of the flows listed in Snowflake's guide:
 4. And now we'll add the scope for the api
    * Click on **Manifest**.
    * Locate the `appRoles` element.
-   * Enter an **App Role** with the following settings.
-   * The App Role manifests as follows.
+   * Enter an **App Role** with the settings below.
 
 | Setting            | Description                                                                                                               |
 | ------------------ | ------------------------------------------------------------------------------------------------------------------------- |
@@ -99,30 +98,20 @@ The App Role manifests as follows.
 
 4. Under the **Redirect URIs** section, enter `https://<your_company_subdomain>.zenlytic.com`\
    a. Ex: `https://mycompany.zenlytic.com`\
-   b. If you're not sure what your subdomain is, reach out to your Zenlytic contact
-5. Select **Access tokens (used for implicit flows)** and **ID tokens (used for implicit and hybrid flows)**
-6. Click Add a Platform
-7. Choose Single-page application
-8. Click Configure
-
-<figure><img src="../../.gitbook/assets/entra-snowflake_image_2.png" alt=""><figcaption></figcaption></figure>
-
-4. Under the **Redirect URIs** section, enter `https://<your_company_subdomain>.zenlytic.com`\
-   a. Ex: `https://mycompany.zenlytic.com`\
    b. If you're not sure what your subdomain is, reach out to your Zenlytic contact or [email support](mailto:support@zenlytic.com)
 5.  Select **Access tokens (used for implicit flows)** and **ID tokens (used for implicit and hybrid flows)**
 
     <figure><img src="../../.gitbook/assets/entra-snowflake_image_3.png" alt=""><figcaption></figcaption></figure>
-6. Click Configure
+6. Click **Configure**
 
 ## Step 2: Create the OAuth Client
 
-1. In the **Overview** section of your `Zenlytic Snowflake` application , copy the `ClientID` from the **Application (client) ID** field.
+1. In the **Overview** section of your `Zenlytic Snowflake` application, copy the `ClientID` from the **Application (client) ID** field.
 2. Click on **Certificates & secrets** and then **New client secret**.
 3. Add a description of the secret.
 4. Select the time period that you feel comfortable with. Once this secret expires, Zenlytic will lose the ability to authenticate with Snowflake. You'll need to generate and share with Zenlytic a new secret before that expires to avoid downtime.
 5. Click **Add**. Copy the secret for later.
-6. Now we need to configure Delegated permissions for the Zenlytic
+6. Now we need to configure Delegated permissions for Zenlytic
    * Click on **API Permissions**.
    * Click on **Add Permission**.
    * Click on **My APIs**.

--- a/docs/authentication-and-security/microsoft_entra_zenlytic.md
+++ b/docs/authentication-and-security/microsoft_entra_zenlytic.md
@@ -19,14 +19,12 @@ This document will guide you through the process of enabling Microsoft Entra (fo
 
 To begin the process, reach out to your Zenlytic contact and let them know you'd like to use Microsoft Entra SSO.
 
-You'll work with them to decide on the Zenlytic subdomain `(ex.mycompany.zenlytic.com`)
+You'll work with them to decide on the Zenlytic subdomain (e.g. `mycompany.zenlytic.com`)
 
 After that conversation, they will provide you with these two important values for future use:
 
-```
 1. `Identifier (Entity ID)`
 2. `Reply URL (Assertion Consumer Service URL)`
-```
 
 ### 2. Creating an Entra Application for Zenlytic
 
@@ -46,10 +44,8 @@ Then click the Create button.
 
 Before continuing, ensure that you have obtained these values from your Zenlytic contact:
 
-```
 1. `Identifier (Entity ID)`
 2. `Reply URL (Assertion Consumer Service URL)`
-```
 
 Now go to your newly created application under the `Enterprise applications` section. Go ahead and click the name to open it.
 
@@ -91,13 +87,13 @@ By default, your mappings will look something like this:
 
 ![Manage Claim](../.gitbook/assets/entra_zenlytic_image_8.png)
 
-In the past we've some users have varying `namespaces` for their claims. So just in case, we'll clear those values out.
+In the past we've seen some users have varying `namespaces` for their claims. So just in case, we'll clear those values out.
 
 Click on each of the claims under `Additional Claims`, and clear out the `Namespace value`
 
 ![Manage Claim](../.gitbook/assets/entra_zenlytic_image_9.png)
 
-Your claim section should now similar to this:
+Your claim section should now look similar to this:
 
 ![Attributes & Claims](../.gitbook/assets/entra_zenlytic_image_10.png)
 
@@ -139,7 +135,7 @@ You may be taken back to the this screen, if so just go back to your application
 
 ![Federation Metadata](../.gitbook/assets/entra_zenlytic_image_12.png)
 
-Once we receive that url, we'll finish up the rest of the setup on our and let you know when you're all set!
+Once we receive that url, we'll finish up the rest of the setup on our end and let you know when you're all set!
 
 ### 6. Adding Users/Groups to Zenlytic
 
@@ -161,7 +157,7 @@ Your Zenlytic contact will let you know when your SSO onboarding is ready for us
 
 ### How-to Set up Custom Claims in Entra
 
-For information on available custom claims, see this section.
+For the full list of available custom claims and their formats, see the [SSO Custom Claims Reference](sso-custom-claims-reference.md).
 
 First we'll go back to the `Single sign-on` section for our App and click `Edit` on `Attributes & Claims`
 


### PR DESCRIPTION
Content pass on the two Entra pages, following the link fix in #130.

## The significant one: duplicated setup steps

`microsoft_entra_snowflake/README.md` → **Set up Redirect URI** ran steps 1–8, then **restarted at 4** and repeated the same three instructions, with `entra-snowflake_image_2.png` embedded twice.

A reader following along configured the redirect URI **twice**, with no way to tell which sequence was authoritative. Now a single 1–6 flow. I kept the better of the two variants — the one carrying the support-email link and the correctly placed `image_3` screenshot.

## Also on the Snowflake page

- *"will need both access to both of the flows"* → *"needs access to both"*
- Removed a duplicated **"The App Role manifests as follows"** — it appeared once as a list item before the settings table and again as prose before the JSON
- Indented the **Important** callout so it sits inside list item 2. It was breaking the ordered list, restarting the numbering at 1 in the rendered output
- Stray space in `application , copy`; *"Delegated permissions for the Zenlytic"*

## Microsoft Entra for Zenlytic

- **Dangling cross-reference fixed.** *"For information on available custom claims, see this section"* linked nowhere. It now points to the [SSO Custom Claims Reference](docs/authentication-and-security/sso-custom-claims-reference.md), which already existed in the same directory.
- **Two lists were wrapped in code fences**, so they rendered as literal code with visible backticks instead of as numbered lists.
- Misplaced backtick: `` `(ex.mycompany.zenlytic.com`) `` → `(e.g. `mycompany.zenlytic.com`)`
- Three grammar errors: *"we've some users have varying"*, *"should now similar to this"*, *"setup on our and let you know"*

## Two things I deliberately left alone

**The H1 "Microsoft Entra Zenlytic"** reads awkwardly next to its sibling "Snowflake with Microsoft Entra". But GitBook derives page slugs from titles, and this is an onboarding page customers get linked to directly during SSO setup. Not worth risking a URL move for phrasing — happy to do it if you'd rather, with a redirect.

**The `zenlytic_role` claim list omits `restricted`**, which `user_roles.md` documents as a real role. Whether the SSO claim actually accepts that value is a question for whoever owns SSO. Guessing wrong here means an admin configures a claim the system rejects, which is worse than the current omission.

## Verification

513 internal links and 209 image references across all four sections — **zero broken**. The new cross-reference target confirmed present.