### PR TITLE
Clear changelog scaffold back to an empty starting page

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -4,30 +4,33 @@ description: What's new in Zenlytic — product updates, new features, and notab
 
 # Changelog
 
-{% hint style="info" %}
-**Scaffold.** Entries below are abbreviated and exist to verify this section renders and generates an RSS feed. Replace before publishing.
-{% endhint %}
+Product updates, new features, and notable changes to Zenlytic.
+
+<!--
+HOW TO ADD AN ENTRY
+
+Wrap entries in a single {% updates %} block, newest first:
 
 {% updates %}
 
-{% update date="2026-07-30" tags="Git" %}
-## Commit identity documented for GitHub deploy keys
+{% update date="2026-07-31" tags="Context Manager" %}
+## Short, specific headline
 
-Zenlytic commits as `Zenlytic <hello@zenlytic.com>` on every save from Context Manager. Organizations enforcing commit-metadata rules now have setup guidance to allow this before connecting.
-
-See [Connecting to GitHub with a deploy key](https://docs.zenlytic.com/authentication-and-security/connecting_to_github_with_a_deploy_key).
-{% endupdate %}
-
-{% update date="2026-07-15" tags="Context Manager" %}
-## Pull from Remote
-
-Pushed changes directly to your data model repo and Zoë isn't seeing them? **Account settings → Pull from Remote** rebuilds the cache from your remote branch.
-{% endupdate %}
-
-{% update date="2026-06-20" tags="Data Modeling" %}
-## Relationships replace identifiers
-
-Joins are now defined with `relationships:` on the model file. Existing `identifiers:` configurations continue to work, but new joins should use Relationships.
+One or two sentences on what changed and why it matters to a user. Link to
+the relevant docs page using an absolute URL:
+[Pull from Remote](https://docs.zenlytic.com/data-modeling/cache-refresh)
 {% endupdate %}
 
 {% endupdates %}
+
+NOTES
+- date="YYYY-MM-DD" is required. It drives ordering and the RSS feed, so use
+  the real ship date, not the date the entry was written.
+- tags are optional. Keep the vocabulary small and reuse it — for example
+  Zoë, Context Manager, Data Modeling, Embedding, Admin, API.
+- Links to other sections must be ABSOLUTE URLs. Relative paths such as
+  ../data-modeling/foo.md do not resolve across a section boundary and
+  GitBook will silently rewrite them into a GitHub URL that 404s.
+- This is a product changelog. Document what changed in Zenlytic, not what
+  changed in the docs.
+-->


### PR DESCRIPTION
Strips the placeholder content so the Changelog starts clean.

## What's removed

Three scaffold entries that existed to prove the section rendered. Only the deploy-key one had a defensible date — the other two were plausible but **invented**. A customer-facing changelog with wrong ship dates is worse than one with no entries, so they're gone rather than reworded.

## Why I didn't seed real entries

Ship dates have to come from whoever owns releases. I checked the obvious proxy — when each feature's docs page first landed in git — and it doesn't hold up:

```
context_manager   2026-… → traces to 2022-09-29 through a rename
clarity_engine    2025-07-30
artifacts         2026-03-05
```

Docs generally lag the feature, and `--follow` walks renames back to unrelated origins. Those dates would look authoritative and be wrong.

## What's left

The heading, a description, and a commented-out template covering:

- `{% updates %}` / `{% update %}` syntax with a worked example
- `date="YYYY-MM-DD"` is required, drives ordering **and the RSS feed**, and should be the real ship date
- Keep the tag vocabulary small and reused (Zoë, Context Manager, Data Modeling, Embedding, Admin, API)
- **Cross-section links must be absolute URLs** — relative paths get silently rewritten to a GitHub URL that 404s, which is the exact bug we fixed in #130
- This is a **product** changelog — what changed in Zenlytic, not what changed in the docs

The HTML comment doesn't render, so the published page is just the heading and one line until a real entry is added.

Section is still Draft — nothing here is customer-visible.

## Before publishing

Worth deciding who owns entries and when they get written. A changelog that goes quiet after two months reads worse than never having started one — tying it to release cadence, rather than to someone remembering, is the thing that makes it survive.