### PR TITLE
Redirect the 404s worth fixing from Jul–Aug analytics

### DIFF
--- a/docs/.gitbook.yaml
+++ b/docs/.gitbook.yaml
@@ -168,3 +168,36 @@ redirects:
   # Stray crawl of Druid query endpoint
   druid/v2/sql: data-sources/druid_setup.md
   druid/v2/sql/: data-sources/druid_setup.md 
+  # ---
+  # Phase 15 — 404s from analytics, Jul 7 – Aug 2 2026
+  # Scanner probes (~50 login/OAuth paths), GitBook page-ID hashes, and
+  # crawler-mangled "&https:/..." URLs are deliberately not redirected.
+
+  # Proactive Agents "inputs" — highest-traffic 404, 19 events across 4 spellings.
+  # No inputs page exists in any naming era; sending to the section landing page.
+  docs/workflows/inputs: proactive-agents/getting-started.md
+  workflows/inputs: proactive-agents/getting-started.md
+  proactive-analytics/inputs: proactive-agents/getting-started.md
+  proactive-agents/inputs: proactive-agents/getting-started.md
+
+  # Bare middle-era section root (the /getting-started etc. variants already resolve)
+  proactive-analytics: proactive-agents/getting-started.md
+
+  # Page exists one level deeper than the requested path
+  legal-and-support/subprocessors: legal-and-support/legal/subprocessors.md
+
+  # Docusaurus-era paths
+  integrations/dbt-metricflow: data-modeling/dbt_metricflow.md
+  tips-and-tricks/2_tips_and_tricks: legacy/zoe_tips_and_tricks.md
+  docs/data_modeling/data_source: data-sources/integrations.md
+
+  # Unsupported Chats lives under zenlytic-ui, not legacy/
+  legacy/unsupported-chats: zenlytic-ui/legacy.md
+
+  # Derived tables are views defined with sql: rather than sql_table_name:
+  derived: data-modeling/view.md
+  derived_table: data-modeling/view.md
+
+  # Marketing content — not documentation
+  pricing: https://www.zenlytic.com/pricing
+  case-studies: https://www.zenlytic.com/case-studies


### PR DESCRIPTION
Triaged the 92 reported 404s into real reader traffic vs. automated noise. **14 redirects added; ~75 URLs deliberately left alone.**

## Fixed

| Requested URL | Now goes to | Events |
|---|---|---|
| `/docs/workflows/inputs` + 3 other spellings | `proactive-agents/getting-started` | **19** |
| `/proactive-analytics` (bare) | `proactive-agents/getting-started` | 4 |
| `/legal-and-support/subprocessors` | `legal-and-support/legal/subprocessors` | 4 |
| `/integrations/dbt-metricflow` | `data-modeling/dbt_metricflow` | 2 |
| `/pricing` | `www.zenlytic.com/pricing` | 2 |
| `/case-studies` | `www.zenlytic.com/case-studies` | 2 |
| `/derived`, `/derived_table` | `data-modeling/view` | 2 |
| `/tips-and-tricks/2_tips_and_tricks` | `legacy/zoe_tips_and_tricks` | 1 |
| `/docs/data_modeling/data_source` | `data-sources/integrations` | 1 |
| `/legacy/unsupported-chats` | `zenlytic-ui/legacy` | 1 |

**The standout:** a Proactive Agents **"inputs"** page is being requested under four different names — `docs/workflows/inputs`, `workflows/inputs`, `proactive-analytics/inputs`, `proactive-agents/inputs` — 19 events, 17 visitors. That's the single biggest 404 source and it spans all three naming eras, which suggests a real page that existed in the Docusaurus site and never got carried over. Worth asking whether Proactive Agent inputs/parameters need documenting; a redirect to getting-started is a stopgap, not an answer.

Two others are notable because they're *our* mistakes rather than stale inbound links:
- `/legal-and-support/subprocessors` — that page exists, just one level deeper under `legal/`
- `/legacy/unsupported-chats` — I guessed this exact URL earlier in a support article and it was wrong; the page lives at `zenlytic-ui/legacy`

## Deliberately not redirected

- **~50 login/OAuth/SAML probes** — every one between 12:40 and 12:49 AM on Jul 7, single visitor, hitting paths this site has never had (`/users/sign_in`, `/oauth2/authorization/azure`, `/.auth/login/aad`, `/admin`). A scanner enumerating auth endpoints. Redirecting them would serve 200s to a scanner and gain nothing.
- **8 `/pages/<hash>`** requests using GitBook internal page IDs
- **5 crawler-mangled URLs** with a second full URL concatenated after `&https:/` — not addressable by redirect rules
- `/sitemap_index.xml`, `/opensearch.xml` — routine tooling probes

## Verification

- **129 redirects total, all targets resolve on disk, zero duplicate keys**
- Both external targets return 200