### PR TITLE
Normalize changelog tag vocabulary to new-releases

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -19,7 +19,7 @@ layout:
   actions:
     visible: true
 tags:
-  - new-features
+  - new-releases
   - improvements
   - fixes
 ---
@@ -27,7 +27,7 @@ tags:
 # Product updates
 
 {% updates format="full" %}
-{% update date="2026-07-26" tags="new-releases,new-features,improvements,fixes" %}
+{% update date="2026-07-26" tags="new-releases,improvements,fixes" %}
 ## Proactive Agents for all workspaces
 
 Proactive Agents are now available to all workspaces, plus refreshed signup screens, HTML uploads, and chat and query fixes.
@@ -75,7 +75,7 @@ A refreshed signup flow, smarter Zoë documentation searches, and fixes across a
 * **Cleaner new-chat drawers** — Explore and context drawers initialize and clear correctly for deep-linked questions, without leaking prior-chat state.
 {% endupdate %}
 
-{% update date="2026-07-12" tags="new-releases,new-features,improvements,fixes" %}
+{% update date="2026-07-12" tags="new-releases,improvements,fixes" %}
 ## Zoë looks up product docs before answering
 
 Workspace switching from Add Data, Zoë checking product docs before answering how-to questions, a refreshed login and signup experience, and fixes across MCP connection errors, data model reviews, daily refresh scheduling, SQL generation, and large-workspace exports.
@@ -100,7 +100,7 @@ Workspace switching from Add Data, Zoë checking product docs before answering h
 * **More reliable large-workspace exports** — Screenshot, PDF, and CSV rendering for large dashboards and questions is more reliable and less likely to crash.
 {% endupdate %}
 
-{% update date="2026-07-01" tags="new-releases,new-features,improvements" %}
+{% update date="2026-07-01" tags="new-releases,improvements" %}
 ## Artifact folders are generally available
 
 Artifact folders are now generally available, along with table-selection, skill-error, and skill-metadata improvements.
@@ -116,7 +116,7 @@ Artifact folders are now generally available, along with table-selection, skill-
 * **Git-backed skill metadata** — Git-backed workspace skills now show their name, description, required status, and file location in Zoë's skills list. (Data Model Editor)
 {% endupdate %}
 
-{% update date="2026-06-30" tags="new-releases,new-features,improvements" %}
+{% update date="2026-06-30" tags="new-releases,improvements" %}
 ## Claude Sonnet 5 in the model picker
 
 Claude Sonnet 5 in the model picker, plus clearer MCP connection error messages.
@@ -160,7 +160,7 @@ Shared-chat copy and MCP connection fixes.
 * **MCP protocol version header** — MCP connections send the negotiated MCP-Protocol-Version header after initialization, fixing tool calls against servers that require it. (API)
 {% endupdate %}
 
-{% update date="2026-06-24" tags="new-releases,new-features,improvements,fixes" %}
+{% update date="2026-06-24" tags="new-releases,improvements,fixes" %}
 ## Source-data citations on dashboards
 
 Source-data citations on dashboards, Context Manager in chat, plus upload and artifact fixes.
@@ -179,7 +179,7 @@ Source-data citations on dashboards, Context Manager in chat, plus upload and ar
 * **Artifact thumbnails in sandboxes** — Thumbnails now generate correctly for artifacts created in agent sandboxes.
 {% endupdate %}
 
-{% update date="2026-06-23" tags="new-releases,new-features,improvements,fixes" %}
+{% update date="2026-06-23" tags="new-releases,improvements,fixes" %}
 ## Context Manager reaches more surfaces
 
 Context manager reaches more surfaces, plus sandbox and chat-accuracy fixes.
@@ -199,7 +199,7 @@ Context manager reaches more surfaces, plus sandbox and chat-accuracy fixes.
 * **Nested sandbox restore** — Nested directories are restored correctly during sandbox file restore.
 {% endupdate %}
 
-{% update date="2026-06-19" tags="new-releases,improvements,fixes" %}
+{% update date="2026-06-19" tags="new-releases,fixes" %}
 ## Org-admin management and SQL interpretability
 
 Org-admin management and an optional SQL interpretability toggle.
@@ -232,7 +232,7 @@ Scheduling, picker, and permissions improvements, plus chat and SSO fixes.
 * **SSO group assignment** — Re-adding SSO users to groups no longer creates duplicate or errored adds.
 {% endupdate %}
 
-{% update date="2026-06-16" tags="new-releases,new-features" %}
+{% update date="2026-06-16" tags="new-releases" %}
 ## Try Zenlytic with sample data
 
 A quicker way to try Zenlytic with sample data.
@@ -256,7 +256,7 @@ Connection setup polish.
 * **BigQuery dataset field** — Fixes the dataset textbox in the BigQuery browse step. (Data Model Editor)
 {% endupdate %}
 
-{% update date="2026-06-12" tags="new-releases,new-features,improvements,fixes" %}
+{% update date="2026-06-12" tags="new-releases,improvements,fixes" %}
 ## Live editing and onboarding updates
 
 Live editing, onboarding, sharing, and connection fixes.
@@ -300,7 +300,7 @@ Recent Updates and citations redesign, plus several display fixes.
 * **Duplicate table error** — Clearer error when YAML defines duplicate tables. (Data Model Editor)
 {% endupdate %}
 
-{% update date="2026-06-09" tags="new-releases,new-features,improvements,fixes" %}
+{% update date="2026-06-09" tags="new-releases,improvements,fixes" %}
 ## MCP, model, and reliability updates
 
 A large batch of MCP, model, and reliability updates.
@@ -331,7 +331,7 @@ A large batch of MCP, model, and reliability updates.
 * **Artifact CSV recovery** — Missing CSVs are regenerated before an artifact rebuilds.
 {% endupdate %}
 
-{% update date="2026-06-04" tags="new-releases,new-features,improvements,fixes" %}
+{% update date="2026-06-04" tags="new-releases,improvements,fixes" %}
 ## Connectors settings redesign
 
 Connectors settings redesign, BigQuery improvements, and context manager rework.
@@ -356,7 +356,7 @@ Connectors settings redesign, BigQuery improvements, and context manager rework.
 * **Long chat titles** — Retries or truncates chat-title generation when a conversation exceeds context limits.
 {% endupdate %}
 
-{% update date="2026-06-03" tags="new-releases,new-features,improvements,fixes" %}
+{% update date="2026-06-03" tags="new-releases,improvements,fixes" %}
 ## Opus 4 and scheduled-delivery run history
 
 Opus 4, scheduled-delivery run history, and context editing settings.


### PR DESCRIPTION
Fixes a tag inconsistency introduced when change request GITBOOK-3 merged.

## What happened

The GitBook UI **added** a second spelling to entries that already had one, rather than replacing it:

- **11 of 18 entries** ended up carrying both `new-releases` and `new-features`
- **1 entry** (2026-06-19) carried only one of them
- The page-level `tags:` frontmatter declared only one value

Any entry tagged with the undeclared value matched no filter chip — invisible to the TAGS filter, which is the entire point of tagging.

## Fix

**`new-releases`** is the intended vocabulary, matching GitBook's own changelog. Both places that carry it are now aligned:

- the page-level `tags:` frontmatter, which declares the filter chips
- each entry's `tags=` attribute, derived from the `###` subsections present

| Subsection | Tag |
|---|---|
| New features | `new-releases` |
| Improvements | `improvements` |
| Bug fixes | `fixes` |

The subsection heading stays **"New features"** while its tag is `new-releases`. The heading groups content within an entry; the tag categorizes the entry for filtering. They don't need identical wording — but the mapping has to be fixed and written down, which is the whole cause of this bug.

**Verified:** frontmatter and per-entry vocabularies agree, all 18 entries' tags match their subsections exactly, zero occurrences of `new-features`.

## Why it recurs without a written rule

The vocabulary lives in two files that must agree, and both a human editing in the GitBook UI and a scheduled agent writing via git can touch them. `.changelog/curation-rules.md` currently covers content exclusions only — nothing about tags, links, or terminology. That's the durable place to record it, since it's read on every generation run.