### PR TITLE
Add tags, links, and terminology rules to changelog curation

### DIFF
--- a/.changelog/curation-rules.md
+++ b/.changelog/curation-rules.md
@@ -126,6 +126,74 @@ live in the product and asked Zeta directly. [[release-notes-exclude-feature-fla
 terminal one. The watchlist is the mechanism that keeps pending items in
 front of us until LaunchDarkly confirms GA.
 
+## Tags — canonical vocabulary (2026-08-02)
+
+Exactly three tag slugs, derived from the `###` subsections an entry actually
+contains. Never invent one, never use cadence labels like "Weekly update".
+
+| Subsection heading | Tag slug | Library label | Icon |
+| ------------------ | -------- | ------------- | ---- |
+| New features       | `new-releases` | New releases | rocket |
+| Improvements       | `improvements` | Improvements | sparkles |
+| Bug fixes          | `fixes`        | Fixes        | wrench / screwdriver |
+
+Note the heading and its tag differ in wording — "New features" groups content
+inside an entry, `new-releases` categorizes the entry for filtering. That
+mismatch is intentional and must not be "corrected" in either direction.
+
+The vocabulary lives in **four** places that must agree:
+
+1. `changelog/README.md` frontmatter `tags:` — declares the filter chips
+2. each `{% update %}` block's `tags=` attribute
+3. the space's **Library → Tags** — sets the visible label and icon
+4. this file
+
+**Why:** change request GITBOOK-3 added `new-features` alongside the existing
+`new-releases` rather than replacing it, leaving 11 of 18 entries carrying both
+and one carrying only a value the frontmatter no longer declared. A tag absent
+from the frontmatter matches no filter chip, so those entries were silently
+unfilterable — the page looked fine and the feature simply did nothing.
+
+**How to apply:** derive tags mechanically from the subsections present. If a
+tag would fall outside the three above, the entry is structured wrong — fix the
+structure, not the tag.
+
+## Links (2026-08-02)
+
+Links to Zenlytic docs must be **absolute URLs**:
+
+    [Pull from Remote](https://docs.zenlytic.com/data-modeling/cache-refresh)
+
+**Why:** the changelog is its own GitBook section. A relative path such as
+`../data-modeling/cache-refresh.md` does not resolve across a section boundary,
+and GitBook does not error — it silently rewrites the link into a
+`github.com/Zenlytic/zenlytic-docs/...` URL that 404s. The page builds, the link
+looks normal, and the reader is sent off-site. Four links from the Docusaurus
+migration survived this way until 2026-08-02 precisely because nothing failed.
+
+**How to apply:** never emit a relative path from a changelog entry. Verify a
+target resolves before linking it.
+
+## Terminology (2026-08-02)
+
+Current product names. Earlier terms are correct only when describing history.
+
+| Use | Not |
+| --- | --- |
+| Proactive Agents | Workflows, Proactive Analytics |
+| Context Manager  | Data Model Editor |
+| Relationships    | identifiers, Topics (for new joins) |
+| Skills           | Memories (for new context) |
+| Artifacts        | code interpreter |
+
+**Why:** the product renamed twice in a year, and Zeta's source data still
+carries older names — several existing entries were drafted with "(Data Model
+Editor)" trailing them. A changelog announcing a feature under a name the UI no
+longer uses sends readers looking for something that isn't there.
+
+**How to apply:** translate source terminology before drafting. If an item's
+name is ambiguous, describe the surface the user actually sees.
+
 ## Notes
 
 - Exclusions apply to the public, customer-facing changelog only — they do not


### PR DESCRIPTION
`.changelog/curation-rules.md` is read on every generation run, but covered only **content exclusions** — what not to publish. Nothing about format. Three classes of error had no written guard, and all three have already occurred.

Each section follows the file's existing convention: the rule, a **Why** naming the actual incident, and a **How to apply**.

## Tags

Pins the three-slug vocabulary and the heading→tag mapping:

| Subsection | Tag slug | Library label | Icon |
|---|---|---|---|
| New features | `new-releases` | New releases | rocket |
| Improvements | `improvements` | Improvements | sparkles |
| Bug fixes | `fixes` | Fixes | wrench / screwdriver |

Critically, it names the **four places** this vocabulary lives that must agree — page frontmatter, per-entry `tags=`, the space's **Library → Tags** (label and icon), and this file. Any two disagreeing produces a chip that filters nothing.

It also records that "New features" and `new-releases` differ **on purpose**, so nobody later "fixes" one into the other.

*Incident:* GITBOOK-3 added `new-features` alongside `new-releases` instead of replacing it — 11 of 18 entries carried both, one carried only an undeclared value. Those entries were silently unfilterable; nothing looked broken.

## Links

Requires absolute URLs. A relative path doesn't resolve across a section boundary, and GitBook **silently rewrites it into a `github.com/...` URL that 404s** — no build error, link looks normal on the page.

*Incident:* four such links survived the Docusaurus migration undetected for exactly that reason, found and fixed in #130.

## Terminology

Records current product names — Proactive Agents, Context Manager, Relationships, Skills, Artifacts — against the terms they replaced.

*Incident:* Zeta's source data still carries older names; several existing entries were drafted with "(Data Model Editor)" trailing them.

## Verification

Frontmatter vocabulary, per-entry tags, and the vocabulary documented in the rules file all agree.

## Still to do outside this PR

The **Library → Tags** labels and icons are UI-only — no markdown can set them. Set them in the space to match the table above.