### PR TITLE
Settle changelog tag vocabulary on new-features

### DIFF
--- a/.changelog/curation-rules.md
+++ b/.changelog/curation-rules.md
@@ -133,13 +133,12 @@ contains. Never invent one, never use cadence labels like "Weekly update".
 
 | Subsection heading | Tag slug | Library label | Icon |
 | ------------------ | -------- | ------------- | ---- |
-| New features       | `new-releases` | New releases | rocket |
+| New features       | `new-features` | New features | rocket |
 | Improvements       | `improvements` | Improvements | sparkles |
 | Bug fixes          | `fixes`        | Fixes        | wrench / screwdriver |
 
-Note the heading and its tag differ in wording — "New features" groups content
-inside an entry, `new-releases` categorizes the entry for filtering. That
-mismatch is intentional and must not be "corrected" in either direction.
+The tag slug matches its subsection heading in every case, so the mapping is
+mechanical — no translation step, nothing to remember.
 
 The vocabulary lives in **four** places that must agree:
 
@@ -148,11 +147,13 @@ The vocabulary lives in **four** places that must agree:
 3. the space's **Library → Tags** — sets the visible label and icon
 4. this file
 
-**Why:** change request GITBOOK-3 added `new-features` alongside the existing
-`new-releases` rather than replacing it, leaving 11 of 18 entries carrying both
-and one carrying only a value the frontmatter no longer declared. A tag absent
-from the frontmatter matches no filter chip, so those entries were silently
-unfilterable — the page looked fine and the feature simply did nothing.
+**Why:** change request GITBOOK-3 introduced a second spelling alongside the
+first rather than replacing it, leaving 11 of 18 entries carrying both and one
+carrying only a value the frontmatter no longer declared. A tag absent from the
+frontmatter matches no filter chip, so those entries were silently unfilterable
+— the page looked fine and the feature simply did nothing. The vocabulary then
+flipped twice more while we settled on `new-features`, which is what Zenlytic
+has used all along.
 
 **How to apply:** derive tags mechanically from the subsections present. If a
 tag would fall outside the three above, the entry is structured wrong — fix the

--- a/changelog/README.md
+++ b/changelog/README.md
@@ -19,7 +19,7 @@ layout:
   actions:
     visible: true
 tags:
-  - new-releases
+  - new-features
   - improvements
   - fixes
 ---
@@ -27,7 +27,7 @@ tags:
 # Product updates
 
 {% updates format="full" %}
-{% update date="2026-07-26" tags="new-releases,improvements,fixes" %}
+{% update date="2026-07-26" tags="new-features,improvements,fixes" %}
 ## Proactive Agents for all workspaces
 
 Proactive Agents are now available to all workspaces, plus refreshed signup screens, HTML uploads, and chat and query fixes.
@@ -75,7 +75,7 @@ A refreshed signup flow, smarter Zoë documentation searches, and fixes across a
 * **Cleaner new-chat drawers** — Explore and context drawers initialize and clear correctly for deep-linked questions, without leaking prior-chat state.
 {% endupdate %}
 
-{% update date="2026-07-12" tags="new-releases,improvements,fixes" %}
+{% update date="2026-07-12" tags="new-features,improvements,fixes" %}
 ## Zoë looks up product docs before answering
 
 Workspace switching from Add Data, Zoë checking product docs before answering how-to questions, a refreshed login and signup experience, and fixes across MCP connection errors, data model reviews, daily refresh scheduling, SQL generation, and large-workspace exports.
@@ -100,7 +100,7 @@ Workspace switching from Add Data, Zoë checking product docs before answering h
 * **More reliable large-workspace exports** — Screenshot, PDF, and CSV rendering for large dashboards and questions is more reliable and less likely to crash.
 {% endupdate %}
 
-{% update date="2026-07-01" tags="new-releases,improvements" %}
+{% update date="2026-07-01" tags="new-features,improvements" %}
 ## Artifact folders are generally available
 
 Artifact folders are now generally available, along with table-selection, skill-error, and skill-metadata improvements.
@@ -116,7 +116,7 @@ Artifact folders are now generally available, along with table-selection, skill-
 * **Git-backed skill metadata** — Git-backed workspace skills now show their name, description, required status, and file location in Zoë's skills list. (Data Model Editor)
 {% endupdate %}
 
-{% update date="2026-06-30" tags="new-releases,improvements" %}
+{% update date="2026-06-30" tags="new-features,improvements" %}
 ## Claude Sonnet 5 in the model picker
 
 Claude Sonnet 5 in the model picker, plus clearer MCP connection error messages.
@@ -160,7 +160,7 @@ Shared-chat copy and MCP connection fixes.
 * **MCP protocol version header** — MCP connections send the negotiated MCP-Protocol-Version header after initialization, fixing tool calls against servers that require it. (API)
 {% endupdate %}
 
-{% update date="2026-06-24" tags="new-releases,improvements,fixes" %}
+{% update date="2026-06-24" tags="new-features,improvements,fixes" %}
 ## Source-data citations on dashboards
 
 Source-data citations on dashboards, Context Manager in chat, plus upload and artifact fixes.
@@ -179,7 +179,7 @@ Source-data citations on dashboards, Context Manager in chat, plus upload and ar
 * **Artifact thumbnails in sandboxes** — Thumbnails now generate correctly for artifacts created in agent sandboxes.
 {% endupdate %}
 
-{% update date="2026-06-23" tags="new-releases,improvements,fixes" %}
+{% update date="2026-06-23" tags="new-features,improvements,fixes" %}
 ## Context Manager reaches more surfaces
 
 Context manager reaches more surfaces, plus sandbox and chat-accuracy fixes.
@@ -199,7 +199,7 @@ Context manager reaches more surfaces, plus sandbox and chat-accuracy fixes.
 * **Nested sandbox restore** — Nested directories are restored correctly during sandbox file restore.
 {% endupdate %}
 
-{% update date="2026-06-19" tags="new-releases,fixes" %}
+{% update date="2026-06-19" tags="new-features,fixes" %}
 ## Org-admin management and SQL interpretability
 
 Org-admin management and an optional SQL interpretability toggle.
@@ -232,7 +232,7 @@ Scheduling, picker, and permissions improvements, plus chat and SSO fixes.
 * **SSO group assignment** — Re-adding SSO users to groups no longer creates duplicate or errored adds.
 {% endupdate %}
 
-{% update date="2026-06-16" tags="new-releases" %}
+{% update date="2026-06-16" tags="new-features" %}
 ## Try Zenlytic with sample data
 
 A quicker way to try Zenlytic with sample data.
@@ -256,7 +256,7 @@ Connection setup polish.
 * **BigQuery dataset field** — Fixes the dataset textbox in the BigQuery browse step. (Data Model Editor)
 {% endupdate %}
 
-{% update date="2026-06-12" tags="new-releases,improvements,fixes" %}
+{% update date="2026-06-12" tags="new-features,improvements,fixes" %}
 ## Live editing and onboarding updates
 
 Live editing, onboarding, sharing, and connection fixes.
@@ -300,7 +300,7 @@ Recent Updates and citations redesign, plus several display fixes.
 * **Duplicate table error** — Clearer error when YAML defines duplicate tables. (Data Model Editor)
 {% endupdate %}
 
-{% update date="2026-06-09" tags="new-releases,improvements,fixes" %}
+{% update date="2026-06-09" tags="new-features,improvements,fixes" %}
 ## MCP, model, and reliability updates
 
 A large batch of MCP, model, and reliability updates.
@@ -331,7 +331,7 @@ A large batch of MCP, model, and reliability updates.
 * **Artifact CSV recovery** — Missing CSVs are regenerated before an artifact rebuilds.
 {% endupdate %}
 
-{% update date="2026-06-04" tags="new-releases,improvements,fixes" %}
+{% update date="2026-06-04" tags="new-features,improvements,fixes" %}
 ## Connectors settings redesign
 
 Connectors settings redesign, BigQuery improvements, and context manager rework.
@@ -356,7 +356,7 @@ Connectors settings redesign, BigQuery improvements, and context manager rework.
 * **Long chat titles** — Retries or truncates chat-title generation when a conversation exceeds context limits.
 {% endupdate %}
 
-{% update date="2026-06-03" tags="new-releases,improvements,fixes" %}
+{% update date="2026-06-03" tags="new-features,improvements,fixes" %}
 ## Opus 4 and scheduled-delivery run history
 
 Opus 4, scheduled-delivery run history, and context editing settings.


### PR DESCRIPTION
`new-features` is what Zenlytic has used all along. Updates all three places that carry the vocabulary so they agree.

| Subsection | Tag slug | Library label | Icon |
|---|---|---|---|
| New features | `new-features` | New features | rocket |
| Improvements | `improvements` | Improvements | sparkles |
| Bug fixes | `fixes` | Fixes | wrench / screwdriver |

## Changed

- `changelog/README.md` frontmatter `tags:` — declares the filter chips
- Each `{% update %}` block's `tags=` attribute
- The canonical table in `.changelog/curation-rules.md`

## A simplification worth noting

Every slug now matches its subsection heading exactly, so the mapping is mechanical — nothing to translate, nothing to remember.

The curation rules previously carried a paragraph explaining that "New features" and its tag differed **deliberately**, warning against "correcting" one into the other. That caveat is now removed, because there's no longer a mismatch to explain. One less thing that can be mistaken for a bug and re-broken later.

The **Why** in that section still records the GITBOOK-3 incident, since the underlying failure mode — a tag absent from the frontmatter matches no filter chip, silently — is what the rule guards against regardless of which spelling won.

## Verification

- Frontmatter, per-entry attributes, and the rules document all carry the same three values
- Every entry's tags match its subsections exactly
- Zero occurrences of `new-releases` remain in either file

## Still UI-only

**Library → Tags** labels and icons can't be set from markdown. Set them to match the table above once this merges — that's the fourth place the vocabulary lives.