### PR TITLE
Move changelog format spec into curation rules and enforce it in CI

### DIFF
--- a/.changelog/curation-rules.md
+++ b/.changelog/curation-rules.md
@@ -195,6 +195,74 @@ longer uses sends readers looking for something that isn't there.
 **How to apply:** translate source terminology before drafting. If an item's
 name is ambiguous, describe the surface the user actually sees.
 
+## Output format (2026-08-02)
+
+**File:** `changelog/README.md`. Nothing else in that directory.
+
+**Never modify:**
+
+- The YAML frontmatter — `description`, the `layout:` block, and the page-level
+  `tags:` list. GitBook manages these; overwriting them resets page settings and
+  breaks tag filtering.
+- The H1 `# Product updates`. It is not "Changelog". It is the page title and
+  drives the page URL.
+- `changelog/SUMMARY.md`, which reads `* [Product updates](README.md "2026")`.
+  The quoted `"2026"` is the navigation label, not part of the title.
+
+**Only edit** inside `{% updates format="full" %}`. Add new entries at the top;
+leave existing entries untouched.
+
+Entry shape:
+
+    {% update date="YYYY-MM-DD" tags="new-features,improvements,fixes" %}
+    ## Short headline naming the most significant change
+
+    One sentence summarizing the release.
+
+    ### New features
+
+    * **Feature name** — What it does and why it matters.
+
+    ### Improvements
+
+    * **Short label** — What changed.
+
+    ### Bug fixes
+
+    * **Short label** — What was fixed.
+    {% endupdate %}
+
+- `date` is the real ship date. It renders in the left gutter and drives both
+  ordering and the RSS feed.
+- The `##` heading is a **headline, never a date**. Not "Week of July 20–26" —
+  the date already displays from the attribute, and this heading populates the
+  on-page navigation and the anchor link. A date here makes the nav a column of
+  dates instead of a scannable list of what shipped.
+- `###` subsections are limited to New features, Improvements, Bug fixes. Omit
+  any with no content.
+- Bullets use `* **Bold label** — description.`
+- Never create year pages such as `2025.md`. The annual rollover is a manual
+  step: archive the closing year into its own page, empty this one, and change
+  the `"2026"` link title.
+
+**Why:** the page header is owned by GitBook and the entries are owned by this
+pipeline, in the same file. Every incident so far came from one side
+overwriting the other's half.
+
+**How to apply:** treat everything above the `{% updates %}` line as read-only.
+
+## Enforcement (2026-08-02)
+
+`.github/workflows/validate-changelog.yml` checks every push and pull request
+touching `changelog/`. It fails on a wrong H1, a tag outside the vocabulary,
+tags that disagree with an entry's subsections, a date used as a headline, an
+unexpected subsection heading, or a relative link.
+
+**Why:** a rules file only works if it is read. CI does not rely on that — a
+run that ignores these rules fails visibly instead of publishing quietly.
+
+**How to apply:** if the check fails, fix the entry rather than the check.
+
 ## Notes
 
 - Exclusions apply to the public, customer-facing changelog only — they do not

--- a/.github/scripts/validate_changelog.py
+++ b/.github/scripts/validate_changelog.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Validate changelog/README.md against .changelog/curation-rules.md.
+
+The changelog is written by a scheduled agent and edited through the GitBook
+UI. A rules file only helps if it gets read; this check does not depend on
+that. Every failure below has already happened at least once.
+"""
+import re
+import sys
+from pathlib import Path
+
+PATH = Path("changelog/README.md")
+VOCAB = ["new-features", "improvements", "fixes"]
+SUBSECTION_TAG = {
+    "New features": "new-features",
+    "Improvements": "improvements",
+    "Bug fixes": "fixes",
+}
+H1 = "# Product updates"
+
+errors = []
+
+
+def fail(msg):
+    errors.append(msg)
+
+
+text = PATH.read_text(encoding="utf-8")
+
+# --- page header, owned by GitBook -----------------------------------------
+if not re.search(rf"^{re.escape(H1)}$", text, re.M):
+    fail(f'H1 must be exactly "{H1}". GitBook owns the page title; changing it '
+         f"moves the page URL.")
+
+fm = re.search(r"^tags:\n((?:  - \S+\n)+)", text, re.M)
+if not fm:
+    fail("Frontmatter is missing a tags: list. It declares the filter chips; "
+         "without it, tags match nothing.")
+else:
+    declared = re.findall(r"^  - (\S+)$", fm.group(1), re.M)
+    if sorted(declared) != sorted(VOCAB):
+        fail(f"Frontmatter tags: is {declared}, expected {VOCAB}.")
+
+if "{% updates" not in text:
+    fail("No {% updates %} block found.")
+
+# --- entries ----------------------------------------------------------------
+entries = list(
+    re.finditer(
+        r'\{% update date="([^"]*)" tags="([^"]*)" %\}\s*\n(.*?)\{% endupdate %\}',
+        text,
+        re.S,
+    )
+)
+if not entries:
+    fail("No {% update %} entries parsed. Check the block syntax.")
+
+for m in entries:
+    date, tags_attr, body = m.group(1), m.group(2), m.group(3)
+    label = date or "<no date>"
+
+    if not re.fullmatch(r"\d{4}-\d{2}-\d{2}", date):
+        fail(f"[{label}] date must be YYYY-MM-DD.")
+
+    heading = re.search(r"^## (.+)$", body, re.M)
+    if not heading:
+        fail(f"[{label}] missing a '## ' headline.")
+    elif re.match(r"^(Week of |[A-Z][a-z]+ \d{1,2},? \d{4}$)", heading.group(1).strip()):
+        fail(f'[{label}] "## {heading.group(1).strip()}" is a date, not a headline. '
+             f"The date already renders from the attribute; this heading drives "
+             f"the on-page nav and anchor.")
+
+    subs = re.findall(r"^### (.+)$", body, re.M)
+    for s in subs:
+        if s.strip() not in SUBSECTION_TAG:
+            fail(f'[{label}] unexpected subsection "### {s.strip()}". '
+                 f"Allowed: {', '.join(SUBSECTION_TAG)}.")
+
+    tags = [t for t in tags_attr.split(",") if t]
+    unknown = [t for t in tags if t not in VOCAB]
+    if unknown:
+        fail(f"[{label}] tag(s) {unknown} outside the vocabulary {VOCAB}.")
+
+    expected = {SUBSECTION_TAG[s.strip()] for s in subs if s.strip() in SUBSECTION_TAG}
+    if set(tags) != expected:
+        fail(f"[{label}] tags {sorted(tags)} do not match subsections "
+             f"{sorted(expected)}. Tags are derived from the ### sections present.")
+
+# --- links ------------------------------------------------------------------
+for m in re.finditer(r"(?<!!)\[[^\]]*\]\(([^)]+)\)", text):
+    href = m.group(1).strip()
+    if href.startswith(("http://", "https://", "#", "mailto:")):
+        continue
+    fail(f'Relative link "{href}". Cross-section links must be absolute URLs — '
+         f"GitBook silently rewrites unresolvable relative paths into GitHub "
+         f"links that 404.")
+
+# --- report -----------------------------------------------------------------
+if errors:
+    print(f"Changelog validation failed ({len(errors)} problem(s)):\n")
+    for e in errors:
+        print(f"  - {e}")
+    print("\nRules: .changelog/curation-rules.md")
+    sys.exit(1)
+
+print(f"Changelog OK — {len(entries)} entries, vocabulary {VOCAB}.")

--- a/.github/workflows/validate-changelog.yml
+++ b/.github/workflows/validate-changelog.yml
@@ -1,0 +1,23 @@
+name: Validate changelog
+
+# Enforces the format rules in .changelog/curation-rules.md. The changelog is
+# written by a scheduled agent and edited through the GitBook UI, so a rules
+# file alone is not enough — this fails loudly instead of publishing quietly.
+
+on:
+  pull_request:
+    paths:
+      - 'changelog/**'
+  push:
+    branches: [main]
+    paths:
+      - 'changelog/**'
+  workflow_dispatch:
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check changelog format
+        run: python3 .github/scripts/validate_changelog.py


### PR DESCRIPTION
Answers two problems: the format spec lived in a Cowork prompt where nobody could see or review it, and nothing verified that a run actually followed it.

## 1. Spec moved into the repo

`.changelog/curation-rules.md` gains an **Output format** section. That file is already read on every generation run — its first line says so — so the spec no longer needs to be pasted into a prompt and maintained by hand.

It covers the file to edit, the parts GitBook owns that the pipeline must not touch (frontmatter, the `# Product updates` H1, `SUMMARY.md`), the entry shape, and the manual annual rollover.

The framing that matters: **the page header is owned by GitBook and the entries are owned by this pipeline, in the same file.** Every incident so far came from one side overwriting the other's half.

## 2. CI that doesn't depend on the rules being read

A rules file only works if it gets read. `validate-changelog.yml` runs on every push and PR touching `changelog/` and fails on:

| Check | Has happened |
|---|---|
| H1 other than `# Product updates` | ✓ |
| Frontmatter `tags:` ≠ the three-value vocabulary | ✓ |
| A tag outside the vocabulary | ✓ (GITBOOK-3) |
| Tags disagreeing with the `###` subsections | ✓ |
| A date used as the `##` headline | ✓ |
| Unexpected `###` subsection heading | — |
| A relative link | ✓ (#130) |

Every check exists because something went wrong, not speculatively.

## Verified

- Current file **passes**: 18 entries, correct vocabulary
- Injected each failure mode; all caught:

```
h1        → 1 error
tag       → 8 errors
datehead  → 1 error
mismatch  → 3 errors
```

A check that never fails is worthless, so this was tested in both directions.

## What Cowork still needs

One line, instead of a pasted spec:

> Read `.changelog/curation-rules.md` and follow every rule in it before drafting.

If a run ignores it, CI fails on the PR rather than publishing quietly to a live customer-facing page.