### PR TITLE
Document Live Queries retroactivity and delivery preview permissions

### DIFF
--- a/docs/zenlytic-ui/artifacts.md
+++ b/docs/zenlytic-ui/artifacts.md
@@ -21,6 +21,8 @@ Each artifact bundles together four components:
 
 Live Queries keep an artifact's numbers current. Dashboards, charts, and other HTML artifacts don't store the results Zoë pulled — they store the queries behind them and re-run those queries against your warehouse every time you open the artifact. Open a dashboard Zoë built last month and you see this morning's data, with no action on your part.
 
+Artifacts created before Live Queries were available don't gain them on their own, and rebuilding one won't convert it. To add Live Queries to an existing artifact, ask Zoë to do it.
+
 {% hint style="info" %}
 **Live Queries run with your permissions.** When you open an artifact, its Live Queries run as you, scoped to the data you're allowed to see. Two people can open the same artifact and see different numbers, and you will never see data in an artifact that you couldn't query yourself.
 {% endhint %}
@@ -167,6 +169,8 @@ Before each delivery, Zenlytic re-runs any Live Queries in the artifact and rend
 ### Delivering artifacts with Live Queries
 
 An artifact's file can't run its Live Queries outside Zenlytic, so deliveries skip the attachment even when **Include attachments** is on. Recipients get the preview image and a **View in Zenlytic** link instead, along with a short note explaining why no file was attached. Opening the artifact from that link runs the Live Queries with the recipient's own permissions.
+
+The preview image itself is rendered with the schedule owner's permissions. Deliveries go to email addresses and Slack channels rather than to verified Zenlytic accounts, so there's no recipient identity to scope those queries to.
 
 ### Run history
 


### PR DESCRIPTION
Two behaviors engineering confirmed that the artifacts page didn't cover. Both are prose additions; nothing else on the page moved.

## 1. Live Queries aren't retroactive

**Live Queries** section, after the intro paragraph and before the permissions hint:

> Artifacts created before Live Queries were available don't gain them on their own, and rebuilding one won't convert it. To add Live Queries to an existing artifact, ask Zoë to do it.

Rebuilding is the natural thing to try, and it doesn't work — worth saying before someone concludes the feature is broken.

## 2. The delivery preview image carries the owner's permissions

**Delivering artifacts with Live Queries**, underneath the existing paragraph:

> The preview image itself is rendered with the schedule owner's permissions. Deliveries go to email addresses and Slack channels rather than to verified Zenlytic accounts, so there's no recipient identity to scope those queries to.

That section already says opening the artifact from the **View in Zenlytic** link runs queries as the *recipient* — which invites the assumption the emailed image is scoped the same way. It isn't, and the reason is structural rather than a design choice.

## Two judgment calls

**Dropped one sentence from the drafted text.** The third sentence — recipients opening from the link see it with their own permissions — is already the closing sentence of the paragraph directly above. Same reasoning as not duplicating the Delivery intro.

**Prose, not hints.** The page reserves `{% hint %}` for standing cautions (the permissions hint, the publishing warning). Both additions clarify mechanics, and the Delivery intro already carries the caution — "Keep that in mind when adding recipients whose own access is narrower."

## Note on the file

The page publishes to `docs.zenlytic.com/using-zenlytic/artifacts` but lives at `docs/zenlytic-ui/artifacts.md` — there is no `using-zenlytic` directory. GitBook derives URLs from `SUMMARY.md` nesting (the `## Using Zenlytic` heading), not from repo paths.

Wording follows the Live Queries reframe in c651512 rather than the "live artifact" phrasing that preceded it.

**Verified:** 509 internal links across the docs section still resolve, zero broken.