### PR TITLE
Document inviting users, and correct what SSO provisioning does

### DIFF
--- a/.cursor/rules/contribution-style-guide.mdc
+++ b/.cursor/rules/contribution-style-guide.mdc
@@ -28,6 +28,24 @@ You are writing directly to the **customer** and **telling them what to do**. Be
 - **Avoid jargon:** Use simple, clear language accessible to all skill levels
 - **Define acronyms:** Spell out on first use, then use the acronym
 
+### Never editorialize about the reader
+
+Describe the product. Do not narrate how the reader is expected to feel about it, and do not stage-manage their attention.
+
+❌ **Never write:**
+
+- "This is the part that surprises people."
+- "This trips people up."
+- "Here's the thing…" / "The good news is…" / "Don't panic."
+- "You might think X, but actually Y."
+- "Believe it or not" / "counterintuitively" / "the catch is"
+
+✅ **Write the fact directly instead:**
+
+> Inviting someone to a workspace gives them access to that workspace only.
+
+If a behavior genuinely needs emphasis, use bold or a `{% hint %}` — not a sentence telling the reader they're about to be surprised. Assume the reader is capable and short on time. Anything that would sound patronizing read aloud does not belong on the page.
+
 ## 📁 File Structure and Organization
 
 ### Markdown Files (.md)

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -39,6 +39,7 @@
 
 ## Administration
 
+* [Inviting and Managing Users](zenlytic-ui/inviting-users.md)
 * [User Roles](zenlytic-ui/user_roles.md)
 * [User Attributes](zenlytic-ui/user_attributes.md)
 * [Workspace Groups And Permissions](zenlytic-ui/workspace_groups_and_permissions.md)

--- a/docs/zenlytic-ui/inviting-users.md
+++ b/docs/zenlytic-ui/inviting-users.md
@@ -27,7 +27,7 @@ You don't have to get the role right at invite time. It can be changed later fro
 
 ## Access is granted per workspace
 
-This is the part that surprises people. **Inviting someone to a workspace gives them access to that workspace only.** If your organization has three workspaces and someone needs all three, they have to be invited to each one, and their role is set separately in each.
+**Inviting someone to a workspace gives them access to that workspace only.** If your organization has three workspaces and someone needs all three, they have to be invited to each one, and their role is set separately in each.
 
 **Organization Admin is the one exception.** It applies across every workspace in the organization automatically — grant it in one place and it takes effect everywhere. That's also why it's the only role that can create new workspaces.
 

--- a/docs/zenlytic-ui/inviting-users.md
+++ b/docs/zenlytic-ui/inviting-users.md
@@ -1,0 +1,68 @@
+---
+description: >-
+  Invite people to a workspace, assign their role, and manage existing members
+  from the Team page.
+---
+
+# Inviting and Managing Users
+
+Every person who uses Zenlytic belongs to one or more workspaces. You add them from **Workspace Settings → Team**.
+
+## Invite someone
+
+1. Go to **Workspace Settings → Team**.
+2. Click **+ Team Member**.
+3. Enter their **email address**.
+4. Choose a **role**. This is required — there's no default.
+5. Optionally add them to one or more **groups**.
+6. Click **Submit**.
+
+They receive an email with a link to join the workspace. Until they accept, the invitation sits under the **Invites** tab.
+
+You don't have to get the role right at invite time. It can be changed later from **Team → Users**.
+
+{% hint style="info" %}
+**Who can invite:** Admins and Organization Admins. Other roles don't see the **+ Team Member** button.
+{% endhint %}
+
+## Access is granted per workspace
+
+This is the part that surprises people. **Inviting someone to a workspace gives them access to that workspace only.** If your organization has three workspaces and someone needs all three, they have to be invited to each one, and their role is set separately in each.
+
+**Organization Admin is the one exception.** It applies across every workspace in the organization automatically — grant it in one place and it takes effect everywhere. That's also why it's the only role that can create new workspaces.
+
+For what each role can do, see [User Roles](user_roles.md).
+
+## Manage existing members
+
+**Team → Users** lists everyone in the workspace, with their role, login method, and whether MFA is enabled.
+
+From here you can:
+
+* **Change someone's role** — use the role dropdown on their row. The change takes effect immediately.
+* **Change or remove several people at once** — select them with the checkboxes, then apply a role change or removal to the whole selection.
+* **Remove someone** — this revokes their access to this workspace. It does not affect their access to any other workspace, and it does not delete their Zenlytic account.
+
+Use [groups](workspace_groups_and_permissions.md) rather than per-person changes when you're managing access at any scale.
+
+## New workspaces and SSO provisioning
+
+Only Organization Admins can create workspaces, and the first step asks whether to enable **SSO User Provisioning**.
+
+* **Enabled** — the new workspace inherits all the users from your main organization workspace. They arrive with access already granted.
+* **Disabled** (the default) — the new workspace starts empty and every member has to be invited manually.
+
+Turning it on is the difference between a workspace your team can use immediately and one you have to populate by hand, so decide deliberately at creation time.
+
+Provisioning can also be toggled later for an existing workspace from [Workspace Manager](workspace-manager.md).
+
+{% hint style="warning" %}
+If your organization signs in through SSO, workspace access can also be driven by claims in the SSO assertion. Workspaces removed from a user's claim are revoked on their next sign-in **even if access was originally granted by invitation**. See the [SSO Custom Claims Reference](../authentication-and-security/sso-custom-claims-reference.md).
+{% endhint %}
+
+## Related pages
+
+* [User Roles](user_roles.md) — what each role can do, and the permissions behind them
+* [Workspace Groups and Permissions](workspace_groups_and_permissions.md) — grouping users and assigning access at scale
+* [Workspace Manager](workspace-manager.md) — creating workspaces and managing them across an organization
+* [User Attributes](user_attributes.md) — controlling which data a user can see

--- a/docs/zenlytic-ui/workspace-manager.md
+++ b/docs/zenlytic-ui/workspace-manager.md
@@ -31,7 +31,7 @@ You can find the Workspace Manager from the navigation bar, next to Settings. Th
 
 For each workspace, you can:
 
-* **Toggle SSO User Provisioning** — When enabled, users who sign in through SSO are automatically added to this workspace. When disabled, users must be manually invited.
+* **Toggle SSO User Provisioning** — When enabled, the workspace inherits the users from your main organization workspace. When disabled, users must be [invited manually](inviting-users.md).
 * **Delete a workspace** — Removes the workspace from active use. You'll be asked to type the workspace name to confirm. Deleted workspaces are deactivated and hidden but not permanently destroyed. You cannot delete the workspace you are currently signed into.
 
 ***
@@ -43,7 +43,7 @@ Click **"Create New Workspace"** to walk through a guided setup:
 #### Step 1: Name and Provisioning
 
 * Enter a name for the new workspace.
-* Choose whether to enable **SSO User Provisioning** (off by default).
+* Choose whether to enable **SSO User Provisioning** (off by default). When enabled, the new workspace inherits all the users from your main organization workspace. When left off, it starts empty and every member has to be [invited manually](inviting-users.md).
 
 #### Step 2: Add Database Connections
 


### PR DESCRIPTION
A customer asked how to invite someone to a workspace and there was nothing to point them at.

"Invite" appeared three times in the docs, never as the subject:

- `workspace-manager.md:34` — *"users must be manually invited"*, without saying how
- `workspace-manager.md:68` — *"When you invite a new member…"*, assuming you already know
- `sso-custom-claims-reference.md:88` — a passing reference

## New page: Inviting and Managing Users

Placed **first** in Administration — it's the entry point, whereas User Roles is the reference you consult after deciding to invite someone.

- **The invite flow** — Workspace Settings → Team → **+ Team Member**, with email, a required role, and optional groups
- **Who can invite** — Admins and Organization Admins
- **Managing members** — Team → Users, inline role changes, and the bulk selection that shipped 2026-08-02 (also undocumented until now)
- **Pending invitations** — the Invites tab

### The part that actually causes confusion

**Access is granted per workspace.** Inviting someone to one workspace gives them nothing anywhere else, and their role is set separately in each. **Organization Admin is the sole exception** — it spans every workspace automatically, which is also why it's the only role that can create workspaces.

Without that model stated, the per-workspace role dropdowns look like a bug rather than a design.

## Correction: SSO User Provisioning

`workspace-manager.md` defined it as *"users who sign in through SSO are automatically added to this workspace."* That describes a different mechanism.

It actually means the new workspace **inherits the users from your main organization workspace**.

That distinction matters at exactly the wrong moment — an Organization Admin creating a workspace sees "Choose whether to enable SSO User Provisioning (off by default)" with no explanation at all, and the toggle reference elsewhere told them something inaccurate. The explanation now sits on the **Step 1** creation line where the decision gets made, not only in the reference.

## Verification

527 links across all four sections. The only breaks are the two pre-existing ones on `legal-and-support/legal/README.md`, unrelated and still outstanding.

## Not included

No screenshots. The invite dialog and Team table are simple enough to follow in prose, and the page is worth publishing now given the current answer is nothing. Easy to add later.